### PR TITLE
feat: 支持可配置后端接口地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ cp backend/.env.example backend/.env
 
 # 编辑环境变量，设置你的 OpenAI API Key
 nano backend/.env
+
+# （可选）为前端创建 `.env.local` 环境变量文件
+touch .env.local
 ```
 
 ### 3. 配置 OpenAI API Key
@@ -74,6 +77,16 @@ npm start
 
 1. **聊天界面**: 访问 `http://localhost:3000` 开始与AI助手对话
 2. **监控仪表板**: 访问 `http://localhost:3000/telemetry` 查看遥测数据
+
+### 前端环境变量
+
+在根目录创建 `.env.local` 文件，配置前端请求后端时使用的基础地址：
+
+```env
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
+```
+
+在部署到不同环境时，只需修改该变量，即可让聊天与遥测页面指向新的后端地址。
 
 ## 🔧 API 端点
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Send, Bot, User, Activity, Database, FileText } from "lucide-react";
+import { CHAT_ENDPOINT, API_BASE_URL } from "@/lib/apiConfig";
 
 interface Message {
   id: string;
@@ -78,7 +79,7 @@ export default function ChatPage() {
 
     try {
       // Call the backend API
-      const response = await fetch("http://localhost:3002/api/chat", {
+      const response = await fetch(CHAT_ENDPOINT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json"
@@ -112,7 +113,7 @@ export default function ChatPage() {
       console.error("Error sending message:", error);
       const errorMessage: Message = {
         id: (Date.now() + 1).toString(),
-        content: `抱歉，连接服务器时遇到问题。请确保后端服务运行在3002端口。错误信息: ${error instanceof Error ? error.message : '未知错误'}`,
+        content: `抱歉，连接服务器时遇到问题。请确保后端服务在 ${API_BASE_URL} 上运行并提供 /api/chat 接口。错误信息: ${error instanceof Error ? error.message : '未知错误'}`,
         role: "assistant",
         timestamp: new Date()
       };

--- a/app/telemetry/page.tsx
+++ b/app/telemetry/page.tsx
@@ -17,6 +17,7 @@ import {
   Clock,
   Zap
 } from "lucide-react";
+import { telemetryEndpoint } from "@/lib/apiConfig";
 
 interface TelemetryData {
   traces: any[];
@@ -66,10 +67,10 @@ export default function TelemetryPage() {
       setLoading(true);
 
       const [tracesRes, logsRes, metricsRes, statsRes] = await Promise.all([
-        fetch('http://localhost:3002/api/telemetry/traces?limit=50'),
-        fetch('http://localhost:3002/api/telemetry/logs?limit=100'),
-        fetch('http://localhost:3002/api/telemetry/metrics?limit=50'),
-        fetch('http://localhost:3002/api/telemetry/stats')
+        fetch(`${telemetryEndpoint('traces')}?limit=50`),
+        fetch(`${telemetryEndpoint('logs')}?limit=100`),
+        fetch(`${telemetryEndpoint('metrics')}?limit=50`),
+        fetch(telemetryEndpoint('stats'))
       ]);
 
       const [traces, logs, metrics, stats] = await Promise.all([

--- a/lib/apiConfig.ts
+++ b/lib/apiConfig.ts
@@ -1,0 +1,9 @@
+const DEFAULT_BACKEND_URL = "http://localhost:3001";
+
+const rawBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL ?? DEFAULT_BACKEND_URL;
+
+export const API_BASE_URL = rawBackendUrl.replace(/\/+$/, "");
+
+export const CHAT_ENDPOINT = `${API_BASE_URL}/api/chat`;
+
+export const telemetryEndpoint = (path: string) => `${API_BASE_URL}/api/telemetry/${path}`;


### PR DESCRIPTION
## Summary
- 新增 `lib/apiConfig.ts`，统一定义前端调用后端的基础地址与终端构造
- 聊天与遥测页面改为读取 `NEXT_PUBLIC_BACKEND_URL` 配置，默认指向本地 3001 端口
- 更新 README，说明如何为前端配置 `NEXT_PUBLIC_BACKEND_URL`

## Testing
- npm run lint *(fails: 34 problems (25 errors, 9 warnings) — 现有代码中的 any 类型与未使用变量问题)*

------
https://chatgpt.com/codex/tasks/task_e_68d231c90b0c832b84f778cfed6a2419