### PR TITLE
feat: monitor mcp services with health and quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@
 - 🚧 安全：MCP 接口接入 RBAC + 审计日志，沙箱运行写入 events/agent_runs，并提供前端 Integrations/Agents 管理页面。
 - 🚧 架构：整理 AOS v0.1 MCP 优先蓝图，明确 IA/接口/数据模型与 M0-M2 里程碑（详见 `docs/aos-v0.1-blueprint.md`）。
 - 🚧 后端：引入 MCP 网关/注册表、沙箱脚本调度骨架，现持久化到 Postgres，支持 `/mcp/*` 接口与 Agent 脚本定时执行。
+- ✅ 事件总线：落地 Postgres Outbox `value_events` 表，提供 `/api/events` 查询与 SSE 订阅，前端 Chat Hub 实时展示任务收据、审批与异常。
+- 🚧 Projects：新增 `/api/projects` 路由与回放视图，支持查看时间线、产物并重跑任务写入价值事件。
 - 🚧 Agents：沙箱脚本支持虚拟环境管理，自动提供默认环境，并在独立「沙箱」页面维护变量，运行时可复用共享配置。
+- ✅ Integrations：提供 MCP 服务健康巡检、熔断与配额策略管理，页面可视化成功率/延迟并一键调整策略。
 - ✅ 后端：Express + LangGraph 聊天代理已完成，支持会话上下文、SSE 流式输出与 OpenAI 模型配置。
 - ✅ 后端：LangGraph 检查点存储迁移至 PostgreSQL，复用连接池并自动同步 schema 注释。
 - ✅ 后端：OpenTelemetry 埋点生效，遥测数据现已切换至 NATS JetStream，按类型划分 `telemetry.*` 主题流，并通过 `/api/telemetry/*` API 读取追踪、日志、指标以及统计信息。
 - ✅ 前端：Next.js 聊天工作台上线，具备本地多会话存储、追踪 ID 展示以及实时输入提示，默认连通流式聊天接口。
 - ✅ 前端：遥测仪表板页面可视化最近追踪、日志、指标，并可回放本地历史会话、关联 Trace 详情。
+- ✅ Telemetry：新增 Trace 瀑布视图与层级时间轴，支持从 Chat 价值事件一键跳转并通过 URL `traceId` 参数定位指定追踪。
 
 ## 🚀 特性
 
@@ -135,6 +139,13 @@ NEXT_PUBLIC_BACKEND_URL=http://localhost:3001
 - `GET /api/telemetry/logs` - 获取日志数据
 - `GET /api/telemetry/metrics` - 获取指标数据
 - `GET /api/telemetry/stats` - 获取统计信息
+
+### 项目与回放 API
+
+- `GET /api/projects` - 获取项目列表与运行摘要
+- `GET /api/projects/:projectId` - 查看项目详情（运行记录、SOP 版本）
+- `GET /api/projects/:projectId/runs/:runId` - 查看运行详情（时间线、产物、Trace ID）
+- `POST /api/projects/:projectId/runs` - 触发新运行或重跑指定任务
 
 ## 📊 监控功能
 

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -9,7 +9,53 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { getMcpEndpoint } from "@/lib/apiConfig";
 import { getStoredApiToken, onApiTokenChange, setStoredApiToken } from "@/lib/authToken";
-import { Plug, RefreshCw } from "lucide-react";
+import { AlertTriangle, Plug, RefreshCw } from "lucide-react";
+
+type HealthState = "healthy" | "degraded" | "unreachable";
+
+interface McpServiceStatus {
+  name: string;
+  health: HealthState;
+  message?: string;
+  lastSuccessAt?: string;
+  lastErrorAt?: string;
+  lastCheckedAt?: string;
+  lastManualCheck?: {
+    status: HealthState;
+    latencyMs?: number;
+    message?: string;
+    checkedAt: string;
+  };
+  metrics: {
+    totalCalls: number;
+    successCount: number;
+    failureCount: number;
+    errorRate: number;
+    p50Latency?: number;
+    p95Latency?: number;
+    consecutiveFailures: number;
+  };
+  policy: {
+    quota?: {
+      limitPerMinute?: number;
+      burstMultiplier?: number;
+    };
+    circuitBreaker?: {
+      failureThreshold: number;
+      cooldownSeconds: number;
+      minimumSamples?: number;
+    };
+  };
+  quota: {
+    limitPerMinute?: number;
+    currentUsage: number;
+    burstMultiplier: number;
+  };
+  circuit: {
+    open: boolean;
+    releaseAt?: string;
+  };
+}
 
 interface ServiceRecord {
   name: string;
@@ -19,6 +65,7 @@ interface ServiceRecord {
   authToken?: string;
   timeoutMs?: number;
   allowedRoles?: string[] | null;
+  status?: McpServiceStatus;
 }
 
 const roleOptions = [
@@ -47,6 +94,14 @@ type FormState = {
   allowedRoles: string[];
 };
 
+interface PolicyFormState {
+  quotaLimitPerMinute: string;
+  quotaBurstMultiplier: string;
+  circuitFailureThreshold: string;
+  circuitCooldownSeconds: string;
+  circuitMinimumSamples: string;
+}
+
 const createEmptyForm = (): FormState => ({
   mode: "create",
   name: "",
@@ -70,6 +125,59 @@ export default function IntegrationsPage() {
   const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState<FormState>(createEmptyForm);
   const [isFormVisible, setFormVisible] = useState(false);
+  const [expandedService, setExpandedService] = useState<string | null>(null);
+  const [policyForms, setPolicyForms] = useState<Record<string, PolicyFormState>>({});
+  const [policyErrors, setPolicyErrors] = useState<Record<string, string | null>>({});
+  const [healthErrors, setHealthErrors] = useState<Record<string, string | null>>({});
+  const [policySaving, setPolicySaving] = useState<string | null>(null);
+  const [checkingService, setCheckingService] = useState<string | null>(null);
+
+  const healthText: Record<HealthState, string> = {
+    healthy: "健康",
+    degraded: "性能下降",
+    unreachable: "不可达",
+  };
+
+  const healthClass: Record<HealthState, string> = {
+    healthy: "bg-emerald-100 text-emerald-700 border border-emerald-200",
+    degraded: "bg-amber-100 text-amber-700 border border-amber-200",
+    unreachable: "bg-red-100 text-red-700 border border-red-200",
+  };
+
+  const buildPolicyForm = (status?: McpServiceStatus): PolicyFormState => ({
+    quotaLimitPerMinute:
+      status?.policy.quota?.limitPerMinute != null ? String(status.policy.quota.limitPerMinute) : "",
+    quotaBurstMultiplier:
+      status?.policy.quota?.burstMultiplier != null ? String(status.policy.quota.burstMultiplier) : "1.2",
+    circuitFailureThreshold:
+      status?.policy.circuitBreaker?.failureThreshold != null
+        ? String(status.policy.circuitBreaker.failureThreshold)
+        : "3",
+    circuitCooldownSeconds:
+      status?.policy.circuitBreaker?.cooldownSeconds != null
+        ? String(status.policy.circuitBreaker.cooldownSeconds)
+        : "60",
+    circuitMinimumSamples:
+      status?.policy.circuitBreaker?.minimumSamples != null
+        ? String(status.policy.circuitBreaker.minimumSamples)
+        : "5",
+  });
+
+  const formatTime = (value?: string) => {
+    if (!value) return "—";
+    try {
+      return new Date(value).toLocaleString();
+    } catch {
+      return value;
+    }
+  };
+
+  const formatLatency = (value?: number) => {
+    if (value == null) return "—";
+    return `${Math.round(value)} ms`;
+  };
+
+  const formatPercent = (value: number) => `${(value * 100).toFixed(1)}%`;
 
   useEffect(() => {
     const stored = getStoredApiToken();
@@ -89,6 +197,33 @@ export default function IntegrationsPage() {
       fetchServices();
     }
   }, [apiToken]);
+
+  useEffect(() => {
+    setPolicyForms((prev) => {
+      const next = { ...prev } as Record<string, PolicyFormState>;
+      let changed = false;
+      const names = new Set(services.map((service) => service.name));
+      for (const service of services) {
+        if (!next[service.name]) {
+          next[service.name] = buildPolicyForm(service.status);
+          changed = true;
+        }
+      }
+      for (const key of Object.keys(next)) {
+        if (!names.has(key)) {
+          delete next[key];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [services]);
+
+  useEffect(() => {
+    if (expandedService && !services.some((service) => service.name === expandedService)) {
+      setExpandedService(null);
+    }
+  }, [services, expandedService]);
 
   const authorizedHeaders = useMemo(() => {
     if (!apiToken) return undefined;
@@ -110,12 +245,16 @@ export default function IntegrationsPage() {
         method: "GET",
         headers: authorizedHeaders,
       });
+      const data = (await response.json().catch(() => ({}))) as {
+        services?: ServiceRecord[];
+        error?: string;
+      };
       if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        throw new Error(body.error ?? `加载失败 (${response.status})`);
+        throw new Error(data.error ?? `加载失败 (${response.status})`);
       }
-      const data = (await response.json()) as { services: ServiceRecord[] };
       setServices(data.services ?? []);
+      setHealthErrors({});
+      setPolicyErrors({});
     } catch (err) {
       setError(err instanceof Error ? err.message : "加载失败");
     } finally {
@@ -226,6 +365,137 @@ export default function IntegrationsPage() {
     setStoredApiToken(apiToken);
   };
 
+  const togglePolicySection = (service: ServiceRecord) => {
+    setPolicyErrors((prev) => ({ ...prev, [service.name]: null }));
+    setExpandedService((prev) => (prev === service.name ? null : service.name));
+    setPolicyForms((prev) => ({
+      ...prev,
+      [service.name]: prev[service.name] ?? buildPolicyForm(service.status),
+    }));
+  };
+
+  const updatePolicyField = (
+    serviceName: string,
+    field: keyof PolicyFormState,
+    value: string,
+  ) => {
+    setPolicyForms((prev) => {
+      const next = { ...prev } as Record<string, PolicyFormState>;
+      const currentStatus = services.find((item) => item.name === serviceName)?.status;
+      next[serviceName] = {
+        ...(next[serviceName] ?? buildPolicyForm(currentStatus)),
+        [field]: value,
+      } as PolicyFormState;
+      return next;
+    });
+  };
+
+  const parseNumberInput = (value: string): number | undefined => {
+    if (!value || !value.trim()) return undefined;
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      throw new Error("请输入合法的数值");
+    }
+    return parsed;
+  };
+
+  const savePolicy = async (service: ServiceRecord) => {
+    if (!apiToken) {
+      setError("请先配置 API Token");
+      return;
+    }
+    const formState = policyForms[service.name] ?? buildPolicyForm(service.status);
+    try {
+      const payload = {
+        quota: {
+          limitPerMinute: parseNumberInput(formState.quotaLimitPerMinute),
+          burstMultiplier: parseNumberInput(formState.quotaBurstMultiplier),
+        },
+        circuitBreaker: {
+          failureThreshold: parseNumberInput(formState.circuitFailureThreshold),
+          cooldownSeconds: parseNumberInput(formState.circuitCooldownSeconds),
+          minimumSamples: parseNumberInput(formState.circuitMinimumSamples),
+        },
+      };
+
+      setPolicySaving(service.name);
+      setPolicyErrors((prev) => ({ ...prev, [service.name]: null }));
+
+      const response = await fetch(
+        getMcpEndpoint(`/registry/${encodeURIComponent(service.name)}/policies`),
+        {
+          method: "PATCH",
+          headers: authorizedHeaders,
+          body: JSON.stringify(payload),
+        },
+      );
+      const data = (await response.json().catch(() => ({}))) as {
+        status?: McpServiceStatus;
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(data.error ?? "更新策略失败");
+      }
+      if (data.status) {
+        setServices((prev) =>
+          prev.map((item) => (item.name === service.name ? { ...item, status: data.status } : item)),
+        );
+        setPolicyForms((prev) => ({
+          ...prev,
+          [service.name]: buildPolicyForm(data.status),
+        }));
+      }
+    } catch (err) {
+      setPolicyErrors((prev) => ({
+        ...prev,
+        [service.name]: err instanceof Error ? err.message : "更新策略失败",
+      }));
+    } finally {
+      setPolicySaving(null);
+    }
+  };
+
+  const triggerHealthCheck = async (service: ServiceRecord) => {
+    if (!apiToken) {
+      setError("请先配置 API Token");
+      return;
+    }
+    setCheckingService(service.name);
+    setHealthErrors((prev) => ({ ...prev, [service.name]: null }));
+    try {
+      const response = await fetch(
+        getMcpEndpoint(`/registry/${encodeURIComponent(service.name)}/health-check`),
+        {
+          method: "POST",
+          headers: authorizedHeaders,
+        },
+      );
+      const data = (await response.json().catch(() => ({}))) as {
+        status?: McpServiceStatus;
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(data.error ?? "健康检查失败");
+      }
+      if (data.status) {
+        setServices((prev) =>
+          prev.map((item) => (item.name === service.name ? { ...item, status: data.status } : item)),
+        );
+        setPolicyForms((prev) => ({
+          ...prev,
+          [service.name]: buildPolicyForm(data.status),
+        }));
+      }
+    } catch (err) {
+      setHealthErrors((prev) => ({
+        ...prev,
+        [service.name]: err instanceof Error ? err.message : "健康检查失败",
+      }));
+    } finally {
+      setCheckingService(null);
+    }
+  };
+
   return (
     <div className="max-w-5xl mx-auto py-10 px-4 space-y-6">
       <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
@@ -279,20 +549,41 @@ export default function IntegrationsPage() {
         {services.map((service) => (
           <Card key={service.name} className="flex flex-col justify-between">
             <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg">{service.name}</CardTitle>
-                <div className="flex gap-2">
-                  <Button variant="outline" size="sm" onClick={() => openEditForm(service)}>
-                    编辑
-                  </Button>
-                  <Button variant="outline" size="sm" onClick={() => deleteService(service.name)}>
-                    删除
-                  </Button>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg">{service.name}</CardTitle>
+                      <p className="text-sm text-muted-foreground break-all">{service.baseUrl}</p>
+                    </div>
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => triggerHealthCheck(service)}
+                        disabled={checkingService === service.name}
+                      >
+                        {checkingService === service.name ? (
+                          <RefreshCw className="h-4 w-4 animate-spin" />
+                        ) : (
+                          "健康检查"
+                        )}
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => togglePolicySection(service)}>
+                        {expandedService === service.name ? "收起策略" : "策略配置"}
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => openEditForm(service)}>
+                        编辑
+                      </Button>
+                      <Button variant="outline" size="sm" onClick={() => deleteService(service.name)}>
+                        删除
+                      </Button>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <p className="text-sm text-muted-foreground break-all">{service.baseUrl}</p>
             </CardHeader>
-            <CardContent className="space-y-3">
+            <CardContent className="space-y-4">
               {service.description && (
                 <p className="text-sm text-muted-foreground">{service.description}</p>
               )}
@@ -314,6 +605,137 @@ export default function IntegrationsPage() {
                   )}
                 </div>
               </div>
+
+              {service.status ? (
+                <div className="space-y-2 rounded-md border border-muted-foreground/20 bg-muted/20 p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">健康状态</span>
+                    <span
+                      className={`rounded-full px-2 py-1 text-xs font-semibold ${healthClass[service.status.health]}`}
+                    >
+                      {healthText[service.status.health]}
+                    </span>
+                  </div>
+                  {service.status.message && (
+                    <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+                      {service.status.message}
+                    </p>
+                  )}
+                  <div className="grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                    <div>近 50 次错误率：{formatPercent(service.status.metrics.errorRate)}</div>
+                    <div>连续失败：{service.status.metrics.consecutiveFailures}</div>
+                    <div>P50 耗时：{formatLatency(service.status.metrics.p50Latency)}</div>
+                    <div>P95 耗时：{formatLatency(service.status.metrics.p95Latency)}</div>
+                    <div>最近成功：{formatTime(service.status.lastSuccessAt)}</div>
+                    <div>最近错误：{formatTime(service.status.lastErrorAt)}</div>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {service.status.quota.limitPerMinute
+                      ? `配额：${service.status.quota.currentUsage}/${service.status.quota.limitPerMinute} 次/分钟 · 突发 ${service.status.quota.burstMultiplier}x`
+                      : `配额：未设置限额（当前 ${service.status.quota.currentUsage} 次/分钟）`}
+                  </div>
+                  {service.status.lastManualCheck && (
+                    <div className="text-xs text-muted-foreground">
+                      最近巡检：{formatTime(service.status.lastManualCheck.checkedAt)} ·
+                      {` ${healthText[service.status.lastManualCheck.status]}`}
+                      {service.status.lastManualCheck.latencyMs != null
+                        ? ` · ${Math.round(service.status.lastManualCheck.latencyMs)} ms`
+                        : ""}
+                      {service.status.lastManualCheck.message
+                        ? ` · ${service.status.lastManualCheck.message}`
+                        : ""}
+                    </div>
+                  )}
+                  {service.status.circuit.open && (
+                    <div className="text-xs text-destructive">
+                      熔断中，预计恢复：{formatTime(service.status.circuit.releaseAt)}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="rounded-md border border-dashed border-muted-foreground/30 p-3 text-xs text-muted-foreground">
+                  暂无监控数据
+                </div>
+              )}
+
+              {healthErrors[service.name] && (
+                <p className="text-xs text-destructive">{healthErrors[service.name]}</p>
+              )}
+
+              {expandedService === service.name && (
+                <div className="space-y-3 border-t border-dashed pt-3">
+                  <h4 className="text-sm font-semibold">速率配额与熔断策略</h4>
+                  <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium text-muted-foreground">每分钟最大调用数</label>
+                      <Input
+                        value={policyForms[service.name]?.quotaLimitPerMinute ?? ""}
+                        placeholder="留空表示不限"
+                        onChange={(event) =>
+                          updatePolicyField(service.name, "quotaLimitPerMinute", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium text-muted-foreground">突发倍率</label>
+                      <Input
+                        value={policyForms[service.name]?.quotaBurstMultiplier ?? ""}
+                        placeholder="默认 1.2"
+                        onChange={(event) =>
+                          updatePolicyField(service.name, "quotaBurstMultiplier", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium text-muted-foreground">熔断阈值（连续失败次数）</label>
+                      <Input
+                        value={policyForms[service.name]?.circuitFailureThreshold ?? ""}
+                        placeholder="默认 3"
+                        onChange={(event) =>
+                          updatePolicyField(service.name, "circuitFailureThreshold", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-xs font-medium text-muted-foreground">冷却时间（秒）</label>
+                      <Input
+                        value={policyForms[service.name]?.circuitCooldownSeconds ?? ""}
+                        placeholder="默认 60"
+                        onChange={(event) =>
+                          updatePolicyField(service.name, "circuitCooldownSeconds", event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1 md:col-span-2">
+                      <label className="text-xs font-medium text-muted-foreground">最少采样次数</label>
+                      <Input
+                        value={policyForms[service.name]?.circuitMinimumSamples ?? ""}
+                        placeholder="默认 5"
+                        onChange={(event) =>
+                          updatePolicyField(service.name, "circuitMinimumSamples", event.target.value)
+                        }
+                      />
+                    </div>
+                  </div>
+                  {policyErrors[service.name] && (
+                    <p className="text-xs text-destructive">{policyErrors[service.name]}</p>
+                  )}
+                  <div className="flex justify-end">
+                    <Button
+                      size="sm"
+                      onClick={() => savePolicy(service)}
+                      disabled={policySaving === service.name}
+                    >
+                      {policySaving === service.name ? (
+                        <RefreshCw className="h-4 w-4 animate-spin" />
+                      ) : (
+                        "保存策略"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
             </CardContent>
           </Card>
         ))}
@@ -424,14 +846,4 @@ export default function IntegrationsPage() {
       )}
     </div>
   );
-}
-
-interface McpServerConfig {
-  name: string;
-  baseUrl: string;
-  description?: string;
-  capabilities: string[];
-  authToken?: string;
-  timeoutMs?: number;
-  allowedRoles?: string[];
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,14 +66,20 @@ interface ValueEvent {
   actionHref?: string;
 }
 
-interface LogEntry {
-  id?: string;
-  timestamp: number;
-  level: string;
-  message: string;
-  trace_id?: string;
-  span_id?: string;
-  attributes?: Record<string, unknown>;
+interface RawValueEvent {
+  id: string;
+  eventType: string;
+  status: string;
+  occurredAt: string;
+  title?: string | null;
+  summary?: string | null;
+  traceId?: string | null;
+  payload?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  action?: {
+    label?: string | null;
+    href?: string | null;
+  } | null;
 }
 
 const isStoredMessageRecord = (value: unknown): value is StoredMessageRecord => {
@@ -131,7 +137,7 @@ export default function ChatPage() {
     responseTime: 0,
     activeTraces: 1
   });
-  const [logStreamSeed, setLogStreamSeed] = useState(0);
+  const [eventStreamSeed, setEventStreamSeed] = useState(0);
 
   const eventTypeMeta: Record<ValueEventType, { label: string; icon: JSX.Element; badgeClass: string }> = {
     progress: {
@@ -163,62 +169,73 @@ export default function ChatPage() {
     error: "border-red-500",
   };
 
-  const mapLogToEvent = useCallback((log: LogEntry): ValueEvent => {
-    const topic = typeof log.attributes?.topic === 'string' ? log.attributes.topic : undefined;
-    const titleAttr = typeof log.attributes?.title === 'string' ? log.attributes.title : undefined;
-    const lowerLevel = (log.level || '').toLowerCase();
+  const mapRawEvent = useCallback((raw: RawValueEvent): ValueEvent => {
+    const normalizedType = (() => {
+      const base = raw.eventType?.toLowerCase?.() ?? '';
+      if (base.includes('anomaly') || base.includes('error') || base.includes('incident')) {
+        return 'anomaly';
+      }
+      if (base.includes('approval') || base.includes('review') || base.includes('acceptance')) {
+        return 'approval';
+      }
+      if (base.includes('receipt') || base.includes('result') || base.includes('complete')) {
+        return 'receipt';
+      }
+      return 'progress';
+    })();
 
-    let type: ValueEventType = 'progress';
-    let status: ValueEventStatus = 'active';
-    let actionLabel: string | undefined;
-    let actionHref: string | undefined;
+    const normalizedStatus = (() => {
+      const base = raw.status?.toLowerCase?.() ?? '';
+      if (['success', 'succeeded', 'done', 'completed'].some(keyword => base.includes(keyword))) {
+        return 'success';
+      }
+      if (['warning', 'pending', 'waiting', 'approval'].some(keyword => base.includes(keyword))) {
+        return 'warning';
+      }
+      if (['error', 'failed', 'anomaly', 'incident'].some(keyword => base.includes(keyword))) {
+        return 'error';
+      }
+      return 'active';
+    })();
 
-    if (topic?.includes('receipt') || lowerLevel === 'success') {
-      type = 'receipt';
-      status = 'success';
-      actionLabel = '查看结果';
-      actionHref = log.trace_id ? `/telemetry?traceId=${encodeURIComponent(log.trace_id)}` : undefined;
-    } else if (topic?.includes('approval') || lowerLevel === 'warn' || lowerLevel === 'warning') {
-      type = 'approval';
-      status = 'warning';
-      actionLabel = '前往审批';
-      actionHref = log.trace_id ? `/projects?traceId=${encodeURIComponent(log.trace_id)}` : '/projects';
-    } else if (topic?.includes('anomaly') || lowerLevel === 'error') {
-      type = 'anomaly';
-      status = 'error';
-      actionLabel = '查看追踪';
-      actionHref = log.trace_id ? `/telemetry?traceId=${encodeURIComponent(log.trace_id)}` : undefined;
-    } else {
-      actionLabel = '查看详情';
-      actionHref = log.trace_id ? `/telemetry?traceId=${encodeURIComponent(log.trace_id)}` : undefined;
-    }
+    const payload = raw.payload && typeof raw.payload === 'object' ? raw.payload : {};
+    const summaryCandidate =
+      raw.summary
+      ?? (typeof (payload as Record<string, unknown>).message === 'string' ? (payload as Record<string, unknown>).message : undefined)
+      ?? (typeof raw.title === 'string' ? raw.title : undefined)
+      ?? '收到价值事件通知';
 
-    const iso = new Date(log.timestamp).toISOString();
-    const timeLabel = new Date(log.timestamp).toLocaleTimeString('zh-CN', {
-      hour12: false,
-    });
+    const timestamp = (() => {
+      const parsed = new Date(raw.occurredAt);
+      return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    })();
+
+    const actionLabel = raw.action?.label ?? (raw.traceId ? '查看 Trace' : undefined);
+    const actionHref = raw.action?.href ?? (raw.traceId ? `/telemetry?traceId=${encodeURIComponent(raw.traceId)}` : undefined);
 
     return {
-      id: log.id ?? `${log.timestamp}-${Math.random().toString(36).slice(2, 8)}`,
-      title: titleAttr ?? topic ?? log.message.slice(0, 60) || '日志事件',
-      type,
-      status,
-      timestamp: iso,
-      timeLabel,
-      summary: log.message,
-      traceId: log.trace_id,
-      actionLabel: typeof log.attributes?.action === 'string' ? log.attributes?.action : actionLabel,
-      actionHref,
-    };
+      id: raw.id,
+      title: raw.title ?? raw.eventType ?? '价值事件',
+      type: normalizedType,
+      status: normalizedStatus,
+      timestamp: timestamp.toISOString(),
+      timeLabel: timestamp.toLocaleTimeString('zh-CN', {
+        hour12: false,
+      }),
+      summary: summaryCandidate,
+      traceId: raw.traceId ?? undefined,
+      actionLabel: actionLabel,
+      actionHref: actionHref,
+    } satisfies ValueEvent;
   }, []);
 
-  const upsertLogEvent = useCallback((log: LogEntry) => {
-    const event = mapLogToEvent(log);
+  const upsertValueEvent = useCallback((raw: RawValueEvent) => {
+    const event = mapRawEvent(raw);
     setValueEvents(prev => {
       const filtered = prev.filter(item => item.id !== event.id);
       return [event, ...filtered].slice(0, 50);
     });
-  }, [mapLogToEvent]);
+  }, [mapRawEvent]);
 
   const ValueEventFeed = ({ compact = false }: { compact?: boolean }) => (
     <div className="flex flex-col gap-3">
@@ -309,7 +326,7 @@ export default function ChatPage() {
         if (prev === normalized) {
           return prev;
         }
-        setLogStreamSeed((seed) => seed + 1);
+        setEventStreamSeed((seed) => seed + 1);
         return normalized;
       });
     });
@@ -329,37 +346,37 @@ export default function ChatPage() {
 
     const fetchInitial = async () => {
       try {
-        const res = await fetch(`${base}/api/logs?limit=30`, {
+        const res = await fetch(`${base}/api/events?limit=30`, {
           headers: {
             Authorization: `Bearer ${apiToken}`,
           },
         });
         if (!res.ok) return;
         const json = await res.json();
-        const logs = Array.isArray(json.logs) ? (json.logs as LogEntry[]) : [];
-        setValueEvents(logs.map(mapLogToEvent));
+        const events = Array.isArray(json.events) ? (json.events as RawValueEvent[]) : [];
+        setValueEvents(events.map(mapRawEvent));
       } catch (error) {
-        console.error('加载初始日志失败', error);
+        console.error('加载价值事件失败', error);
       }
     };
 
     fetchInitial();
 
-    const source = new EventSource(`${base}/api/logs/stream?token=${encodeURIComponent(apiToken)}`);
+    const source = new EventSource(`${base}/api/events/stream?token=${encodeURIComponent(apiToken)}`);
 
     source.onmessage = (event) => {
       try {
-        const log = JSON.parse(event.data) as LogEntry;
-        upsertLogEvent(log);
+        const valueEvent = JSON.parse(event.data) as RawValueEvent;
+        upsertValueEvent(valueEvent);
       } catch (error) {
-        console.error('解析日志流失败', error);
+        console.error('解析价值事件流失败', error);
       }
     };
 
     source.onerror = () => {
       source.close();
       if (!cancelled) {
-        setTimeout(() => setLogStreamSeed(prev => prev + 1), 5000);
+        setTimeout(() => setEventStreamSeed(prev => prev + 1), 5000);
       }
     };
 
@@ -367,7 +384,7 @@ export default function ChatPage() {
       cancelled = true;
       source.close();
     };
-  }, [apiToken, isClient, mapLogToEvent, upsertLogEvent, logStreamSeed]);
+  }, [apiToken, isClient, mapRawEvent, upsertValueEvent, eventStreamSeed]);
 
   const getConversationId = () => {
     if (typeof window === "undefined") return "default";

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,53 +1,320 @@
 "use client";
 
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { ListChecks, PlayCircle, RefreshCcw, RotateCcw } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { ListChecks, PlayCircle, RefreshCcw, RotateCcw, Timer, Workflow } from "lucide-react";
+import {
+  getProjectsEndpoint,
+} from "@/lib/apiConfig";
+import { getStoredApiToken, onApiTokenChange } from "@/lib/authToken";
 
-const mockTasks = [
-  {
-    id: "RUN-1024",
-    title: "视频审核 SOP",
-    status: "进行中",
-    owner: "ops",
-    updatedAt: "5 分钟前",
-  },
-  {
-    id: "RUN-1023",
-    title: "数据集清洗",
-    status: "排队",
-    owner: "ops",
-    updatedAt: "10 分钟前",
-  },
-  {
-    id: "RUN-1022",
-    title: "新功能冒烟测试",
-    status: "已完成",
-    owner: "qa",
-    updatedAt: "25 分钟前",
-  },
-];
+interface RunTimelineEntry {
+  id: string;
+  label: string;
+  status: "pending" | "completed" | "error" | "running";
+  description?: string;
+  occurredAt?: string;
+}
 
-const mockBlueprints = [
-  {
-    id: "SOP-14",
-    name: "AOS 发布流程",
-    version: "v3.2",
-    updatedAt: "昨天 23:10",
-    status: "启用",
-  },
-  {
-    id: "SOP-11",
-    name: "异常恢复模板",
-    version: "v1.4",
-    updatedAt: "两天前",
-    status: "草稿",
-  },
-];
+interface RunArtifact {
+  id: string;
+  name: string;
+  type: "log" | "file" | "dataset" | "report";
+  size: number;
+  downloadUrl?: string;
+}
+
+interface ProjectRunRecord {
+  id: string;
+  projectId: string;
+  title: string;
+  status: "queued" | "running" | "success" | "failed" | "cancelled";
+  owner: string;
+  triggeredBy: string;
+  startedAt: string;
+  finishedAt?: string;
+  traceId: string;
+  summary: string;
+  approvalRequired: boolean;
+  timeline: RunTimelineEntry[];
+  artifacts: RunArtifact[];
+  metadata?: Record<string, unknown>;
+}
+
+interface SopBlueprintVersion {
+  id: string;
+  name: string;
+  version: string;
+  status: "active" | "draft" | "archived";
+  updatedAt: string;
+  description?: string;
+  editor?: string;
+}
+
+interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string;
+  owner: string;
+  tags: string[];
+  latestRun?: ProjectRunRecord;
+  activeRuns: ProjectRunRecord[];
+  queuedRuns: ProjectRunRecord[];
+  completedRuns: ProjectRunRecord[];
+  sopVersions: SopBlueprintVersion[];
+}
+
+const statusBadgeVariant = (status: ProjectRunRecord["status"]) => {
+  switch (status) {
+    case "running":
+      return "default" as const;
+    case "queued":
+      return "outline" as const;
+    case "success":
+      return "secondary" as const;
+    case "failed":
+    case "cancelled":
+      return "destructive" as const;
+    default:
+      return "outline" as const;
+  }
+};
+
+const statusLabel = (status: ProjectRunRecord["status"]) => {
+  switch (status) {
+    case "running":
+      return "执行中";
+    case "queued":
+      return "排队";
+    case "success":
+      return "已完成";
+    case "failed":
+      return "失败";
+    case "cancelled":
+      return "已取消";
+    default:
+      return status;
+  }
+};
+
+const formatBytes = (bytes: number) => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "--";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+};
+
+const formatTime = (iso: string | undefined) => {
+  if (!iso) return "--";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+};
+
+const formatDuration = (run: ProjectRunRecord) => {
+  const start = new Date(run.startedAt).getTime();
+  const end = run.finishedAt ? new Date(run.finishedAt).getTime() : Date.now();
+  if (Number.isNaN(start) || Number.isNaN(end)) return "--";
+  const diff = Math.max(end - start, 0);
+  const minutes = Math.floor(diff / 60000);
+  const seconds = Math.floor((diff % 60000) / 1000);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const restMinutes = minutes % 60;
+    return `${hours} 小时 ${restMinutes} 分`;
+  }
+  if (minutes > 0) {
+    return `${minutes} 分 ${seconds} 秒`;
+  }
+  return `${seconds} 秒`;
+};
+
+const renderTimelineStatus = (status: RunTimelineEntry["status"]) => {
+  switch (status) {
+    case "completed":
+      return "已完成";
+    case "running":
+      return "进行中";
+    case "pending":
+      return "待执行";
+    case "error":
+      return "异常";
+    default:
+      return status;
+  }
+};
 
 export default function ProjectsPage() {
+  const [apiToken, setApiToken] = useState<string | null>(null);
+  const [projects, setProjects] = useState<ProjectSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedRun, setSelectedRun] = useState<ProjectRunRecord | null>(null);
+  const [runModalOpen, setRunModalOpen] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const stored = getStoredApiToken();
+    setApiToken(stored ?? null);
+    const unsubscribe = onApiTokenChange((token) => {
+      setApiToken(token ?? null);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (apiToken) {
+      fetchProjects();
+    } else {
+      setProjects([]);
+      setSelectedProjectId(null);
+    }
+  }, [apiToken, fetchProjects]);
+
+  useEffect(() => {
+    const runId = searchParams.get("run");
+    if (runId && projects.length && !selectedRun) {
+      const project = projects.find((proj) =>
+        [proj.latestRun, ...proj.activeRuns, ...proj.queuedRuns, ...proj.completedRuns].some(
+          (run) => run?.id === runId,
+        ),
+      );
+      if (project) {
+        openRunDetail(project.id, runId);
+      }
+    }
+  }, [projects, searchParams, selectedRun, openRunDetail]);
+
+  const selectedProject = useMemo(() => {
+    if (!selectedProjectId) {
+      return projects[0];
+    }
+    return projects.find((project) => project.id === selectedProjectId) ?? projects[0];
+  }, [projects, selectedProjectId]);
+
+  const authorizedHeaders = useMemo(() => {
+    if (!apiToken) return undefined;
+    return {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    } as Record<string, string>;
+  }, [apiToken]);
+
+  const fetchProjects = useCallback(async () => {
+    if (!apiToken) {
+      setError("请先配置 API Token");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(getProjectsEndpoint(""), {
+        method: "GET",
+        headers: authorizedHeaders,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? `加载失败 (${response.status})`);
+      }
+      const data = (await response.json()) as { projects: ProjectSummary[] };
+      setProjects(data.projects ?? []);
+      if (data.projects?.length && !selectedProjectId) {
+        setSelectedProjectId(data.projects[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "加载失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [apiToken, authorizedHeaders, selectedProjectId]);
+
+  const fetchRun = useCallback(async (projectId: string, runId: string) => {
+    if (!apiToken) return null;
+    try {
+      const response = await fetch(getProjectsEndpoint(`/${projectId}/runs/${runId}`), {
+        method: "GET",
+        headers: authorizedHeaders,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? "加载运行详情失败");
+      }
+      const data = (await response.json()) as { run: ProjectRunRecord };
+      return data.run;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "加载运行详情失败");
+      return null;
+    }
+  }, [apiToken, authorizedHeaders]);
+
+  const openRunDetail = useCallback(
+    async (projectId: string, runId: string) => {
+      const run = await fetchRun(projectId, runId);
+      if (!run) return;
+      setSelectedProjectId(projectId);
+      setSelectedRun(run);
+      setRunModalOpen(true);
+      const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
+      params.set("run", runId);
+      router.replace(`${pathname}?${params.toString()}`);
+    },
+    [fetchRun, pathname, router],
+  );
+
+  const closeRunDetail = useCallback(() => {
+    setRunModalOpen(false);
+    setSelectedRun(null);
+    const params = typeof window !== "undefined" ? new URLSearchParams(window.location.search) : new URLSearchParams();
+    params.delete("run");
+    router.replace(params.size ? `${pathname}?${params.toString()}` : pathname);
+  }, [pathname, router]);
+
+  const triggerRun = useCallback(async (projectId: string, sourceRunId?: string) => {
+    if (!apiToken) {
+      setError("请先配置 API Token");
+      return;
+    }
+    try {
+      const response = await fetch(getProjectsEndpoint(`/${projectId}/runs`), {
+        method: "POST",
+        headers: authorizedHeaders,
+        body: JSON.stringify({ sourceRunId }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? "触发运行失败");
+      }
+      const data = (await response.json()) as { run: ProjectRunRecord };
+      await fetchProjects();
+      await openRunDetail(projectId, data.run.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "触发运行失败");
+    }
+  }, [apiToken, authorizedHeaders, fetchProjects, openRunDetail]);
+
+  const visibleRuns = useMemo(() => {
+    if (!selectedProject) return { current: [], completed: [] as ProjectRunRecord[] };
+    const current = [...selectedProject.activeRuns, ...selectedProject.queuedRuns];
+    const completed = selectedProject.completedRuns;
+    return { current, completed };
+  }, [selectedProject]);
+
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -56,109 +323,285 @@ export default function ProjectsPage() {
             <ListChecks className="h-6 w-6" /> 项目管理
           </h1>
           <p className="text-sm text-muted-foreground">
-            统一查看任务执行、SOP 蓝图与回放记录，支撑 Chat Hub 的价值事件流。
+            打通任务执行、SOP 蓝图与 Chat Hub 价值事件，支持 Trace / 回放联动。
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" size="sm">
-            <RotateCcw className="mr-2 h-4 w-4" /> 重跑最近任务
+          <Button variant="outline" size="sm" onClick={() => fetchProjects()} disabled={loading}>
+            <RefreshCcw className="mr-2 h-4 w-4" /> 刷新
           </Button>
-          <Button size="sm">
-            <PlayCircle className="mr-2 h-4 w-4" /> 新建任务
-          </Button>
+          {selectedProject && (
+            <Button size="sm" onClick={() => triggerRun(selectedProject.id)} disabled={loading}>
+              <PlayCircle className="mr-2 h-4 w-4" /> 新建任务
+            </Button>
+          )}
         </div>
       </div>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between">
-          <div>
-            <CardTitle className="text-lg">进行中任务</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              按状态分组展示最新执行记录，可跳转至回放详情。
-            </p>
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-[240px_minmax(0,1fr)]">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle className="text-base">项目列表</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {projects.length === 0 && (
+              <div className="text-sm text-muted-foreground">
+                {apiToken ? "暂无项目数据" : "请在设置中配置 API Token"}
+              </div>
+            )}
+            {projects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                onClick={() => setSelectedProjectId(project.id)}
+                className={`w-full rounded-md border p-3 text-left text-sm transition-colors hover:bg-muted/70 ${
+                  (selectedProject?.id ?? selectedProjectId) === project.id
+                    ? "border-primary bg-primary/5"
+                    : "border-transparent"
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium">{project.name}</span>
+                  <Badge variant="secondary">{project.tags[0] ?? "--"}</Badge>
+                </div>
+                <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                  {project.description || "未填写描述"}
+                </div>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+
+        {selectedProject && (
+          <div className="flex flex-col gap-4">
+            <Card>
+              <CardHeader className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <CardTitle className="text-lg">当前运行</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    查看排队与执行中的任务，可一键跳转回放。
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  {visibleRuns.current.length > 0 && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => triggerRun(selectedProject.id, visibleRuns.current[0].id)}
+                    >
+                      <RotateCcw className="mr-2 h-4 w-4" /> 重跑当前
+                    </Button>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {visibleRuns.current.length === 0 && (
+                  <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    当前没有排队或执行中的任务。
+                  </div>
+                )}
+                {visibleRuns.current.map((run) => (
+                  <div
+                    key={run.id}
+                    className="flex flex-col gap-2 rounded-lg border p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <span className="font-mono text-xs text-muted-foreground">{run.id}</span>
+                        <span>{run.title}</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        发起人 {run.triggeredBy} · 开始于 {formatTime(run.startedAt)}
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                      <Badge variant={statusBadgeVariant(run.status)}>{statusLabel(run.status)}</Badge>
+                      <Button size="sm" variant="outline" onClick={() => openRunDetail(run.projectId, run.id)}>
+                        查看详情
+                      </Button>
+                      <Button size="sm" variant="ghost" onClick={() => triggerRun(run.projectId, run.id)}>
+                        重跑
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">近期完成</CardTitle>
+                <p className="text-sm text-muted-foreground">按完成时间倒序展示最近记录。</p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {visibleRuns.completed.length === 0 && (
+                  <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    暂无完成记录。
+                  </div>
+                )}
+                {visibleRuns.completed.map((run) => (
+                  <div
+                    key={run.id}
+                    className="flex flex-col gap-2 rounded-lg border p-4 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <span className="font-mono text-xs text-muted-foreground">{run.id}</span>
+                        <span>{run.title}</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        用时 {formatDuration(run)} · 完成于 {formatTime(run.finishedAt)}
+                      </div>
+                    </div>
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                      <Badge variant={statusBadgeVariant(run.status)}>{statusLabel(run.status)}</Badge>
+                      <Button size="sm" variant="outline" onClick={() => openRunDetail(run.projectId, run.id)}>
+                        查看详情
+                      </Button>
+                      <Button size="sm" variant="ghost" onClick={() => triggerRun(run.projectId, run.id)}>
+                        重跑
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">SOP 蓝图版本</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  管理项目 SOP 模板，支持审计编辑历史与一键发布。
+                </p>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-2">
+                {selectedProject.sopVersions.map((bp) => (
+                  <div key={bp.id} className="rounded-lg border p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="font-medium">{bp.name}</div>
+                      <Badge variant={bp.status === "active" ? "default" : "outline"}>
+                        {bp.status === "active" ? "启用" : bp.status === "draft" ? "草稿" : "归档"}
+                      </Badge>
+                    </div>
+                    <div className="mt-2 text-xs text-muted-foreground">
+                      版本 {bp.version} · 更新于 {formatTime(bp.updatedAt)} · 编辑 {bp.editor ?? "--"}
+                    </div>
+                    {bp.description && (
+                      <p className="mt-2 text-xs text-muted-foreground">{bp.description}</p>
+                    )}
+                    <Separator className="my-3" />
+                    <div className="flex gap-2 text-xs">
+                      <Button size="sm" variant="outline">
+                        <Workflow className="mr-2 h-4 w-4" /> 查看 JSON
+                      </Button>
+                      <Button size="sm" variant="ghost">
+                        <Timer className="mr-2 h-4 w-4" /> 发布模板
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
           </div>
-          <Button variant="secondary" size="sm">
-            <RefreshCcw className="mr-2 h-4 w-4" /> 刷新
-          </Button>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {mockTasks.map((task) => (
-            <div
-              key={task.id}
-              className="flex flex-col rounded-lg border p-3 transition-colors hover:bg-muted/60 md:flex-row md:items-center md:justify-between"
-            >
-              <div>
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <span className="font-mono text-xs text-muted-foreground">{task.id}</span>
-                  <span>{task.title}</span>
+        )}
+      </div>
+
+      <Dialog open={runModalOpen} onOpenChange={(open) => (open ? setRunModalOpen(true) : closeRunDetail())}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>运行详情</DialogTitle>
+          </DialogHeader>
+          {selectedRun ? (
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="font-semibold">{selectedRun.title}</span>
+                  <Badge variant={statusBadgeVariant(selectedRun.status)}>{statusLabel(selectedRun.status)}</Badge>
                 </div>
                 <div className="text-xs text-muted-foreground">
-                  负责人 {task.owner} · 更新于 {task.updatedAt}
+                  Run ID: {selectedRun.id} · Trace {selectedRun.traceId}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  发起人 {selectedRun.triggeredBy} · 开始 {formatTime(selectedRun.startedAt)}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  用时 {formatDuration(selectedRun)}
                 </div>
               </div>
-              <div className="mt-2 flex items-center gap-2 md:mt-0">
-                <Badge variant={
-                  task.status === "已完成"
-                    ? "secondary"
-                    : task.status === "进行中"
-                    ? "default"
-                    : "outline"
-                }>
-                  {task.status}
-                </Badge>
-                <Button size="sm" variant="outline">
-                  查看事件
+
+              <div className="rounded-lg border p-4 text-sm">
+                <div className="font-medium">执行摘要</div>
+                <p className="mt-2 text-muted-foreground">{selectedRun.summary}</p>
+              </div>
+
+              <div>
+                <div className="mb-2 text-sm font-medium">执行时间线</div>
+                <ScrollArea className="max-h-64 rounded-lg border p-3 text-sm">
+                  <div className="space-y-3">
+                    {selectedRun.timeline.map((step) => (
+                      <div key={step.id} className="rounded-md border p-3">
+                        <div className="flex items-center justify-between">
+                          <span className="font-medium">{step.label}</span>
+                          <Badge variant="outline">{renderTimelineStatus(step.status)}</Badge>
+                        </div>
+                        {step.description && (
+                          <p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
+                        )}
+                        {step.occurredAt && (
+                          <p className="mt-1 text-xs text-muted-foreground">时间 {formatTime(step.occurredAt)}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </ScrollArea>
+              </div>
+
+              <div>
+                <div className="mb-2 text-sm font-medium">产物</div>
+                {selectedRun.artifacts.length === 0 ? (
+                  <div className="rounded-md border border-dashed p-4 text-center text-xs text-muted-foreground">
+                    暂无产物记录。
+                  </div>
+                ) : (
+                  <div className="space-y-2 text-xs">
+                    {selectedRun.artifacts.map((artifact) => (
+                      <div
+                        key={artifact.id}
+                        className="flex flex-col gap-1 rounded-md border p-3 md:flex-row md:items-center md:justify-between"
+                      >
+                        <div>
+                          <div className="font-medium">{artifact.name}</div>
+                          <div className="text-muted-foreground">
+                            类型 {artifact.type} · 大小 {formatBytes(artifact.size)}
+                          </div>
+                        </div>
+                        <Button size="sm" variant="outline" disabled={!artifact.downloadUrl}>
+                          下载
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => triggerRun(selectedRun.projectId, selectedRun.id)}>
+                  <RotateCcw className="mr-2 h-4 w-4" /> 重跑
                 </Button>
-                <Button size="sm" variant="ghost">
-                  打开回放
-                </Button>
+                <Button onClick={() => closeRunDetail()}>关闭</Button>
               </div>
             </div>
-          ))}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">SOP 蓝图版本</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            版本化管理每个项目的 SOP，支持可视编辑与一键发布。
-          </p>
-        </CardHeader>
-        <CardContent className="grid gap-3 md:grid-cols-2">
-          {mockBlueprints.map((bp) => (
-            <div key={bp.id} className="rounded-lg border p-4">
-              <div className="flex items-center justify-between">
-                <div className="font-medium">{bp.name}</div>
-                <Badge variant={bp.status === "启用" ? "default" : "outline"}>
-                  {bp.status}
-                </Badge>
-              </div>
-              <div className="mt-2 text-xs text-muted-foreground">
-                版本 {bp.version} · 更新于 {bp.updatedAt}
-              </div>
-              <Separator className="my-3" />
-              <div className="flex gap-2 text-xs">
-                <Button size="sm" variant="outline">
-                  查看 JSON
-                </Button>
-                <Button size="sm" variant="ghost">
-                  发布模板
-                </Button>
-              </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">回放 / Replay</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          回放与重跑视图正在规划中，将串联 `task.receipt`、Trace 以及产物下载，并支持审批策略与差异对比。
-        </CardContent>
-      </Card>
+          ) : (
+            <div className="p-6 text-center text-sm text-muted-foreground">正在加载运行详情...</div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/backend/src/auth/permissions.ts
+++ b/backend/src/auth/permissions.ts
@@ -9,7 +9,13 @@ export type Permission =
   | 'mcp.sandbox.execute'
   | 'mcp.logs.read'
   | 'mcp.logs.write'
-  | 'mcp.logs.subscribe';
+  | 'mcp.logs.subscribe'
+  | 'events.read'
+  | 'events.write'
+  | 'events.subscribe'
+  | 'projects.read'
+  | 'projects.write'
+  | 'projects.execute';
 
 const rolePermissions: Record<Role, Permission[]> = {
   owner: [
@@ -22,6 +28,12 @@ const rolePermissions: Record<Role, Permission[]> = {
     'mcp.logs.read',
     'mcp.logs.write',
     'mcp.logs.subscribe',
+    'events.read',
+    'events.write',
+    'events.subscribe',
+    'projects.read',
+    'projects.write',
+    'projects.execute',
   ],
   admin: [
     'mcp.registry.read',
@@ -33,6 +45,12 @@ const rolePermissions: Record<Role, Permission[]> = {
     'mcp.logs.read',
     'mcp.logs.write',
     'mcp.logs.subscribe',
+    'events.read',
+    'events.write',
+    'events.subscribe',
+    'projects.read',
+    'projects.write',
+    'projects.execute',
   ],
   operator: [
     'mcp.registry.read',
@@ -41,11 +59,17 @@ const rolePermissions: Record<Role, Permission[]> = {
     'mcp.sandbox.execute',
     'mcp.logs.read',
     'mcp.logs.subscribe',
+    'events.read',
+    'events.subscribe',
+    'projects.read',
+    'projects.execute',
   ],
   viewer: [
     'mcp.registry.read',
     'mcp.sandbox.read',
     'mcp.logs.read',
+    'events.read',
+    'projects.read',
   ],
 };
 

--- a/backend/src/events/value-events.ts
+++ b/backend/src/events/value-events.ts
@@ -1,0 +1,324 @@
+import { PoolClient } from 'pg';
+import { getPool } from '../db/postgres';
+
+export interface ValueEventAction {
+  label?: string;
+  href?: string;
+}
+
+export interface ValueEventRecord {
+  id: string;
+  eventType: string;
+  status: string;
+  traceId?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  occurredAt: string;
+  payload: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  action: ValueEventAction;
+}
+
+export interface AppendValueEventInput {
+  eventType: string;
+  status?: string;
+  traceId?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  actionLabel?: string | null;
+  actionHref?: string | null;
+  payload?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  occurredAt?: Date;
+}
+
+export const VALUE_EVENT_CHANNEL = 'aos_value_events';
+
+let ensurePromise: Promise<void> | null = null;
+
+type ValueEventRow = {
+  id: string | number;
+  eventType?: string | null;
+  status?: string | null;
+  traceId?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  occurredAt?: string | Date | null;
+  payload?: unknown;
+  metadata?: unknown;
+  actionLabel?: string | null;
+  actionHref?: string | null;
+};
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+};
+
+const mapRowToRecord = (row: ValueEventRow): ValueEventRecord => {
+  const occurredAt = typeof row.occurredAt === 'string'
+    ? row.occurredAt
+    : row.occurredAt instanceof Date
+      ? row.occurredAt.toISOString()
+      : new Date().toISOString();
+
+  return {
+    id: String(row.id),
+    eventType: typeof row.eventType === 'string' && row.eventType.trim() ? row.eventType : 'event',
+    status: typeof row.status === 'string' && row.status.trim() ? row.status : 'active',
+    traceId: typeof row.traceId === 'string' && row.traceId.trim() ? row.traceId : null,
+    title: typeof row.title === 'string' ? row.title : null,
+    summary: typeof row.summary === 'string' ? row.summary : null,
+    occurredAt,
+    payload: isPlainRecord(row.payload) ? row.payload : {},
+    metadata: isPlainRecord(row.metadata) ? row.metadata : {},
+    action: {
+      label: typeof row.actionLabel === 'string' ? row.actionLabel : undefined,
+      href: typeof row.actionHref === 'string' ? row.actionHref : undefined,
+    },
+  } satisfies ValueEventRecord;
+};
+
+const ensureSchemaInternal = async (client: PoolClient) => {
+  await client.query('BEGIN');
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS value_events (
+        id BIGSERIAL PRIMARY KEY,
+        event_type TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        trace_id TEXT,
+        title TEXT,
+        summary TEXT,
+        action_label TEXT,
+        action_href TEXT,
+        payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_value_events_occurred_at
+        ON value_events (occurred_at DESC);
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_value_events_trace_id
+        ON value_events (trace_id);
+    `);
+
+    await client.query(`
+      CREATE OR REPLACE FUNCTION notify_value_events()
+      RETURNS TRIGGER AS $$
+      DECLARE
+        payload JSONB;
+      BEGIN
+        payload := jsonb_build_object(
+          'id', NEW.id::text,
+          'eventType', NEW.event_type,
+          'status', NEW.status,
+          'traceId', NEW.trace_id,
+          'title', NEW.title,
+          'summary', NEW.summary,
+          'occurredAt', NEW.occurred_at,
+          'payload', NEW.payload,
+          'metadata', COALESCE(NEW.metadata, '{}'::jsonb),
+          'action', jsonb_build_object(
+            'label', NEW.action_label,
+            'href', NEW.action_href
+          )
+        );
+        PERFORM pg_notify('${VALUE_EVENT_CHANNEL}', payload::text);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_trigger WHERE tgname = 'value_events_notify_trigger'
+        ) THEN
+          CREATE TRIGGER value_events_notify_trigger
+          AFTER INSERT ON value_events
+          FOR EACH ROW
+          EXECUTE FUNCTION notify_value_events();
+        END IF;
+      END;
+      $$;
+    `);
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  }
+};
+
+export const ensureValueEventInfrastructure = async (): Promise<void> => {
+  if (!ensurePromise) {
+    ensurePromise = (async () => {
+      const pool = getPool();
+      const client = await pool.connect();
+      try {
+        await ensureSchemaInternal(client);
+      } finally {
+        client.release();
+      }
+    })();
+
+    ensurePromise.catch(() => {
+      ensurePromise = null;
+    });
+  }
+
+  return ensurePromise;
+};
+
+export const listValueEvents = async (limit: number = 50): Promise<ValueEventRecord[]> => {
+  await ensureValueEventInfrastructure();
+  const pool = getPool();
+  const capped = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 200) : 50;
+  const { rows } = await pool.query<ValueEventRow>(
+    `
+      SELECT
+        id::text AS id,
+        event_type AS "eventType",
+        status,
+        trace_id AS "traceId",
+        title,
+        summary,
+        action_label AS "actionLabel",
+        action_href AS "actionHref",
+        payload,
+        metadata,
+        occurred_at AS "occurredAt"
+      FROM value_events
+      ORDER BY occurred_at DESC
+      LIMIT $1
+    `,
+    [capped],
+  );
+  return rows.map(mapRowToRecord);
+};
+
+export const appendValueEvent = async (input: AppendValueEventInput): Promise<ValueEventRecord> => {
+  await ensureValueEventInfrastructure();
+  const pool = getPool();
+  const { rows } = await pool.query<ValueEventRow>(
+    `
+      INSERT INTO value_events (
+        event_type,
+        status,
+        trace_id,
+        title,
+        summary,
+        action_label,
+        action_href,
+        payload,
+        metadata,
+        occurred_at
+      ) VALUES (
+        $1,
+        COALESCE(NULLIF($2, ''), 'active'),
+        NULLIF($3, ''),
+        NULLIF($4, ''),
+        NULLIF($5, ''),
+        NULLIF($6, ''),
+        NULLIF($7, ''),
+        $8::jsonb,
+        $9::jsonb,
+        COALESCE($10, NOW())
+      )
+      RETURNING
+        id::text AS id,
+        event_type AS "eventType",
+        status,
+        trace_id AS "traceId",
+        title,
+        summary,
+        action_label AS "actionLabel",
+        action_href AS "actionHref",
+        payload,
+        metadata,
+        occurred_at AS "occurredAt"
+    `,
+    [
+      input.eventType,
+      input.status ?? null,
+      input.traceId ?? null,
+      input.title ?? null,
+      input.summary ?? null,
+      input.actionLabel ?? null,
+      input.actionHref ?? null,
+      JSON.stringify(input.payload ?? {}),
+      JSON.stringify(input.metadata ?? {}),
+      input.occurredAt ?? null,
+    ],
+  );
+
+  return mapRowToRecord(rows[0]);
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null => {
+  return isPlainRecord(value) ? value : null;
+};
+
+const asStringOrNull = (value: unknown): string | null => {
+  return typeof value === 'string' ? value : null;
+};
+
+export const mapNotificationPayload = (payload: unknown): ValueEventRecord => {
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload) as unknown;
+      return mapNotificationPayload(parsed);
+    } catch {
+      return mapRowToRecord({
+        id: 'unknown',
+        eventType: 'event',
+        status: 'active',
+        traceId: null,
+        title: '解析通知失败',
+        summary: payload,
+        occurredAt: new Date().toISOString(),
+        payload: {},
+        metadata: {},
+      });
+    }
+  }
+
+  const record = asRecord(payload);
+  if (!record) {
+    return mapRowToRecord({
+      id: 'unknown',
+      eventType: 'event',
+      status: 'active',
+      traceId: null,
+      title: '未知事件',
+      summary: '无法解析价值事件通知。',
+      occurredAt: new Date().toISOString(),
+      payload: {},
+      metadata: {},
+    });
+  }
+
+  const actionRecord = asRecord(record.action);
+
+  const candidate: ValueEventRow = {
+    id: typeof record.id === 'number' || typeof record.id === 'string' ? record.id : 'unknown',
+    eventType: asStringOrNull(record.eventType) ?? undefined,
+    status: asStringOrNull(record.status) ?? undefined,
+    traceId: asStringOrNull(record.traceId),
+    title: asStringOrNull(record.title),
+    summary: asStringOrNull(record.summary),
+    occurredAt: asStringOrNull(record.occurredAt) ?? new Date().toISOString(),
+    payload: record.payload,
+    metadata: record.metadata,
+    actionLabel: asStringOrNull(actionRecord?.label) ?? asStringOrNull(record.actionLabel) ?? undefined,
+    actionHref: asStringOrNull(actionRecord?.href) ?? asStringOrNull(record.actionHref) ?? undefined,
+  };
+
+  return mapRowToRecord(candidate);
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,8 @@ import { mcpRoutes } from './routes/mcp';
 import { initMcpSubsystem } from './mcp/init';
 import { trace } from '@opentelemetry/api';
 import { closePool } from './db/postgres';
+import { valueEventRoutes } from './routes/events';
+import projectsRoutes from './routes/projects';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -76,6 +78,8 @@ app.get('/health', (req, res) => {
 app.use('/api/chat', chatRoutes);
 app.use('/api/telemetry', telemetryRoutes);
 app.use('/api/logs', logRoutes);
+app.use('/api/events', valueEventRoutes);
+app.use('/api/projects', projectsRoutes);
 app.use('/mcp', mcpRoutes);
 
 // 404 handler

--- a/backend/src/mcp/init.ts
+++ b/backend/src/mcp/init.ts
@@ -1,11 +1,13 @@
 import { ensureMcpStorage } from './storage';
 import { mcpRegistry } from './registry';
 import { mcpSandbox } from './sandbox';
+import { mcpMonitor } from './monitor';
 
 export const initMcpSubsystem = async () => {
   await ensureMcpStorage();
   await mcpRegistry.hydrate();
   await mcpSandbox.hydrate();
+  await mcpMonitor.hydrate(mcpRegistry.list());
 
   const serviceCount = mcpRegistry.list().length;
   const environmentCount = mcpSandbox.listEnvironments().length;

--- a/backend/src/mcp/monitor.ts
+++ b/backend/src/mcp/monitor.ts
@@ -1,0 +1,422 @@
+import { McpServerConfig } from './types';
+import {
+  McpPolicyRecord,
+  loadPoliciesFromStorage,
+  savePolicyToStorage,
+} from './storage';
+
+type HealthState = 'healthy' | 'degraded' | 'unreachable';
+
+export interface QuotaPolicy {
+  limitPerMinute?: number;
+  burstMultiplier?: number;
+}
+
+export interface CircuitBreakerPolicy {
+  failureThreshold: number;
+  cooldownSeconds: number;
+  minimumSamples?: number;
+}
+
+export interface ServicePolicy {
+  quota?: QuotaPolicy;
+  circuitBreaker?: CircuitBreakerPolicy;
+}
+
+interface ManualCheck {
+  status: HealthState;
+  checkedAt: number;
+  latencyMs?: number;
+  message?: string;
+}
+
+interface CallSample {
+  timestamp: number;
+  durationMs: number;
+  success: boolean;
+  errorMessage?: string;
+}
+
+interface ServiceMetrics {
+  policy: ServicePolicy;
+  calls: CallSample[];
+  quotaWindow: number[];
+  lastSuccessAt?: number;
+  lastErrorAt?: number;
+  lastErrorMessage?: string;
+  consecutiveFailures: number;
+  circuitOpenUntil?: number;
+  lastManualCheck?: ManualCheck;
+}
+
+export interface ServiceStatus {
+  name: string;
+  health: HealthState;
+  message?: string;
+  lastSuccessAt?: string;
+  lastErrorAt?: string;
+  lastCheckedAt?: string;
+  lastManualCheck?: {
+    status: HealthState;
+    latencyMs?: number;
+    message?: string;
+    checkedAt: string;
+  };
+  metrics: {
+    totalCalls: number;
+    successCount: number;
+    failureCount: number;
+    errorRate: number;
+    p50Latency?: number;
+    p95Latency?: number;
+    consecutiveFailures: number;
+  };
+  policy: ServicePolicy;
+  quota: {
+    limitPerMinute?: number;
+    currentUsage: number;
+    burstMultiplier: number;
+  };
+  circuit: {
+    open: boolean;
+    releaseAt?: string;
+  };
+}
+
+const MAX_SAMPLES = 200;
+
+const defaultCircuitPolicy: CircuitBreakerPolicy = {
+  failureThreshold: 3,
+  cooldownSeconds: 60,
+  minimumSamples: 5,
+};
+
+const defaultQuotaPolicy: QuotaPolicy = {
+  limitPerMinute: undefined,
+  burstMultiplier: 1.2,
+};
+
+class McpServiceMonitor {
+  private readonly metrics = new Map<string, ServiceMetrics>();
+
+  async hydrate(services: McpServerConfig[]): Promise<void> {
+    const policies = await loadPoliciesFromStorage();
+    const policyMap = new Map<string, McpPolicyRecord>(policies.map((item) => [item.name, item]));
+    for (const service of services) {
+      const existing = this.metrics.get(service.name);
+      if (existing) {
+        const refreshedPolicy = this.composePolicy(policyMap.get(service.name));
+        existing.policy = refreshedPolicy;
+        continue;
+      }
+      this.metrics.set(service.name, {
+        policy: this.composePolicy(policyMap.get(service.name)),
+        calls: [],
+        quotaWindow: [],
+        consecutiveFailures: 0,
+      });
+    }
+
+    for (const name of Array.from(this.metrics.keys())) {
+      if (!services.find((service) => service.name === name)) {
+        this.metrics.delete(name);
+      }
+    }
+  }
+
+  register(service: McpServerConfig): void {
+    const existing = this.metrics.get(service.name);
+    if (existing) return;
+    this.metrics.set(service.name, {
+      policy: this.composePolicy(),
+      calls: [],
+      quotaWindow: [],
+      consecutiveFailures: 0,
+    });
+  }
+
+  unregister(name: string): void {
+    this.metrics.delete(name);
+  }
+
+  setPolicy(name: string, policy: ServicePolicy): void {
+    const metrics = this.ensureMetrics(name);
+    metrics.policy = {
+      quota: policy.quota ?? { ...defaultQuotaPolicy },
+      circuitBreaker: policy.circuitBreaker ?? { ...defaultCircuitPolicy },
+    };
+  }
+
+  async persistPolicy(name: string): Promise<void> {
+    const metrics = this.ensureMetrics(name);
+    const circuit = metrics.policy.circuitBreaker ?? defaultCircuitPolicy;
+    const quota = metrics.policy.quota ?? defaultQuotaPolicy;
+    const payload: McpPolicyRecord = {
+      name,
+      quotaLimitPerMinute: quota.limitPerMinute ?? null,
+      quotaBurstMultiplier: quota.burstMultiplier ?? null,
+      circuitFailureThreshold: circuit.failureThreshold ?? null,
+      circuitCooldownSeconds: circuit.cooldownSeconds ?? null,
+      circuitMinimumSamples: circuit.minimumSamples ?? null,
+    };
+    await savePolicyToStorage(payload);
+  }
+
+  beforeCall(name: string): void {
+    const metrics = this.ensureMetrics(name);
+    const now = Date.now();
+    if (metrics.circuitOpenUntil && metrics.circuitOpenUntil > now) {
+      throw Object.assign(new Error('MCP 服务已触发熔断，请稍后重试'), {
+        code: 'circuit_open',
+      });
+    }
+    if (metrics.circuitOpenUntil && metrics.circuitOpenUntil <= now) {
+      metrics.circuitOpenUntil = undefined;
+      metrics.consecutiveFailures = 0;
+    }
+
+    const limit = metrics.policy.quota?.limitPerMinute;
+    const burst = metrics.policy.quota?.burstMultiplier ?? defaultQuotaPolicy.burstMultiplier ?? 1.2;
+    if (limit && limit > 0) {
+      this.pruneQuotaWindow(metrics, now);
+      const allowance = Math.ceil(limit * burst);
+      if (metrics.quotaWindow.length >= allowance) {
+        throw Object.assign(new Error('MCP 服务已超过配置的速率配额'), {
+          code: 'quota_exceeded',
+        });
+      }
+    }
+  }
+
+  observeCall(name: string, sample: Omit<CallSample, 'timestamp'> & { timestamp?: number }): void {
+    const metrics = this.ensureMetrics(name);
+    const timestamp = sample.timestamp ?? Date.now();
+    metrics.calls.push({
+      timestamp,
+      durationMs: sample.durationMs,
+      success: sample.success,
+      errorMessage: sample.errorMessage,
+    });
+    if (metrics.calls.length > MAX_SAMPLES) {
+      metrics.calls.splice(0, metrics.calls.length - MAX_SAMPLES);
+    }
+
+    this.pruneQuotaWindow(metrics, timestamp);
+    metrics.quotaWindow.push(timestamp);
+
+    if (metrics.quotaWindow.length > MAX_SAMPLES) {
+      metrics.quotaWindow.splice(0, metrics.quotaWindow.length - MAX_SAMPLES);
+    }
+
+    if (sample.success) {
+      metrics.lastSuccessAt = timestamp;
+      metrics.consecutiveFailures = 0;
+    } else {
+      metrics.lastErrorAt = timestamp;
+      metrics.lastErrorMessage = sample.errorMessage;
+      metrics.consecutiveFailures += 1;
+      this.tryOpenCircuit(name, metrics);
+    }
+  }
+
+  recordManualCheck(name: string, result: ManualCheck): void {
+    const metrics = this.ensureMetrics(name);
+    metrics.lastManualCheck = result;
+    if (result.status === 'healthy') {
+      metrics.lastSuccessAt = result.checkedAt;
+    }
+    if (result.status === 'unreachable') {
+      metrics.lastErrorAt = result.checkedAt;
+      metrics.lastErrorMessage = result.message;
+    }
+  }
+
+  getStatus(name: string): ServiceStatus {
+    const metrics = this.ensureMetrics(name);
+    return this.composeStatus(name, metrics);
+  }
+
+  listStatuses(): ServiceStatus[] {
+    return Array.from(this.metrics.entries())
+      .map(([name, metric]) => this.composeStatus(name, metric))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private ensureMetrics(name: string): ServiceMetrics {
+    const metrics = this.metrics.get(name);
+    if (metrics) return metrics;
+    const fresh: ServiceMetrics = {
+      policy: this.composePolicy(),
+      calls: [],
+      quotaWindow: [],
+      consecutiveFailures: 0,
+    };
+    this.metrics.set(name, fresh);
+    return fresh;
+  }
+
+  private composePolicy(raw?: McpPolicyRecord): ServicePolicy {
+    const quota: QuotaPolicy | undefined =
+      raw && (raw.quotaLimitPerMinute != null || raw.quotaBurstMultiplier != null)
+        ? {
+            limitPerMinute: raw.quotaLimitPerMinute ?? undefined,
+            burstMultiplier: raw.quotaBurstMultiplier ?? defaultQuotaPolicy.burstMultiplier,
+          }
+        : undefined;
+
+    const circuit: CircuitBreakerPolicy | undefined =
+      raw &&
+      (raw.circuitFailureThreshold != null || raw.circuitCooldownSeconds != null || raw.circuitMinimumSamples != null)
+        ? {
+            failureThreshold: raw.circuitFailureThreshold ?? defaultCircuitPolicy.failureThreshold,
+            cooldownSeconds: raw.circuitCooldownSeconds ?? defaultCircuitPolicy.cooldownSeconds,
+            minimumSamples: raw.circuitMinimumSamples ?? defaultCircuitPolicy.minimumSamples,
+          }
+        : undefined;
+
+    return {
+      quota: quota ?? { ...defaultQuotaPolicy },
+      circuitBreaker: circuit ?? { ...defaultCircuitPolicy },
+    };
+  }
+
+  private pruneQuotaWindow(metrics: ServiceMetrics, now: number): void {
+    const windowStart = now - 60_000;
+    while (metrics.quotaWindow.length > 0 && metrics.quotaWindow[0] < windowStart) {
+      metrics.quotaWindow.shift();
+    }
+  }
+
+  private tryOpenCircuit(name: string, metrics: ServiceMetrics): void {
+    const policy = metrics.policy.circuitBreaker ?? defaultCircuitPolicy;
+    const sampleCount = metrics.calls.length;
+    if (sampleCount < (policy.minimumSamples ?? defaultCircuitPolicy.minimumSamples ?? 5)) {
+      return;
+    }
+
+    if (metrics.consecutiveFailures >= policy.failureThreshold) {
+      metrics.circuitOpenUntil = Date.now() + policy.cooldownSeconds * 1000;
+      metrics.lastManualCheck = {
+        status: 'unreachable',
+        checkedAt: Date.now(),
+        message: '连续失败达到熔断阈值',
+      };
+    }
+  }
+
+  private composeStatus(name: string, metrics: ServiceMetrics): ServiceStatus {
+    const samples = metrics.calls.slice(-50);
+    const totalCalls = samples.length;
+    const failureCount = samples.filter((item) => !item.success).length;
+    const successCount = samples.filter((item) => item.success).length;
+    const errorRate = totalCalls === 0 ? 0 : failureCount / totalCalls;
+    const latencies = samples.filter((item) => item.success).map((item) => item.durationMs).sort((a, b) => a - b);
+
+    const p50Latency = latencies.length ? latencies[Math.floor(latencies.length * 0.5)] : undefined;
+    const p95Latency = latencies.length ? latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] : undefined;
+
+    const quotaLimit = metrics.policy.quota?.limitPerMinute;
+    const burstMultiplier = metrics.policy.quota?.burstMultiplier ?? defaultQuotaPolicy.burstMultiplier ?? 1.2;
+    const now = Date.now();
+    this.pruneQuotaWindow(metrics, now);
+
+    const circuitOpen = metrics.circuitOpenUntil != null && metrics.circuitOpenUntil > now;
+
+    let health: HealthState = 'healthy';
+    let message: string | undefined;
+
+    if (circuitOpen) {
+      health = 'unreachable';
+      message = metrics.lastManualCheck?.message ?? '服务处于熔断状态';
+    } else if (errorRate > 0.3 || metrics.consecutiveFailures >= 2) {
+      health = 'degraded';
+      message = metrics.lastErrorMessage ?? '近期调用失败率偏高';
+    }
+
+    const status: ServiceStatus = {
+      name,
+      health,
+      message,
+      lastSuccessAt: metrics.lastSuccessAt ? new Date(metrics.lastSuccessAt).toISOString() : undefined,
+      lastErrorAt: metrics.lastErrorAt ? new Date(metrics.lastErrorAt).toISOString() : undefined,
+      lastCheckedAt: metrics.calls.length
+        ? new Date(metrics.calls[metrics.calls.length - 1].timestamp).toISOString()
+        : undefined,
+      lastManualCheck: metrics.lastManualCheck
+        ? {
+            status: metrics.lastManualCheck.status,
+            latencyMs: metrics.lastManualCheck.latencyMs,
+            message: metrics.lastManualCheck.message,
+            checkedAt: new Date(metrics.lastManualCheck.checkedAt).toISOString(),
+          }
+        : undefined,
+      metrics: {
+        totalCalls,
+        successCount,
+        failureCount,
+        errorRate,
+        p50Latency,
+        p95Latency,
+        consecutiveFailures: metrics.consecutiveFailures,
+      },
+      policy: metrics.policy,
+      quota: {
+        limitPerMinute: quotaLimit,
+        currentUsage: metrics.quotaWindow.length,
+        burstMultiplier,
+      },
+      circuit: {
+        open: circuitOpen,
+        releaseAt: metrics.circuitOpenUntil ? new Date(metrics.circuitOpenUntil).toISOString() : undefined,
+      },
+    };
+
+    return status;
+  }
+
+  private async probeEndpoint(url: string, timeoutMs: number): Promise<ManualCheck> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const started = Date.now();
+    try {
+      const response = await fetch(url, {
+        method: 'HEAD',
+        signal: controller.signal,
+      });
+      const latency = Date.now() - started;
+      if (response.ok) {
+        return {
+          status: 'healthy',
+          checkedAt: Date.now(),
+          latencyMs: latency,
+        };
+      }
+      return {
+        status: 'degraded',
+        checkedAt: Date.now(),
+        latencyMs: latency,
+        message: `HTTP ${response.status}`,
+      };
+    } catch (error) {
+      return {
+        status: 'unreachable',
+        checkedAt: Date.now(),
+        message: error instanceof Error ? error.message : '无法访问服务',
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async runHealthCheck(service: McpServerConfig): Promise<ManualCheck> {
+    const endpoint = new URL(service.baseUrl);
+    const probe = await this.probeEndpoint(endpoint.toString(), Math.min(service.timeoutMs ?? 30_000, 10_000));
+    this.recordManualCheck(service.name, probe);
+    if (probe.status === 'healthy') {
+      this.ensureMetrics(service.name).consecutiveFailures = 0;
+    }
+    return probe;
+  }
+}
+
+export const mcpMonitor = new McpServiceMonitor();

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,0 +1,183 @@
+import { Router } from 'express';
+import { getPool } from '../db/postgres';
+import { getAuthContext, requireAuth } from '../auth/middleware';
+import {
+  appendValueEvent,
+  ensureValueEventInfrastructure,
+  listValueEvents,
+  mapNotificationPayload,
+  VALUE_EVENT_CHANNEL,
+  ValueEventRecord,
+} from '../events/value-events';
+
+const router = Router();
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> => {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+};
+
+router.get('/', requireAuth('events.read'), async (req, res) => {
+  const traceId = res.locals.traceId;
+  try {
+    const limit = req.query.limit ? Number(req.query.limit) : 50;
+    const events = await listValueEvents(limit);
+
+    res.json({
+      events,
+      count: events.length,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('[Events] 查询失败:', error);
+    res.status(500).json({
+      error: '查询价值事件失败',
+      traceId,
+    });
+  }
+});
+
+router.post('/', requireAuth('events.write'), async (req, res) => {
+  const traceId = res.locals.traceId;
+  const body = req.body as Record<string, unknown> | undefined;
+
+  const eventType = typeof body?.eventType === 'string' ? body?.eventType.trim() : '';
+  if (!eventType) {
+    return res.status(400).json({
+      error: 'eventType 必填',
+      traceId,
+    });
+  }
+
+  const status = typeof body?.status === 'string' ? body.status.trim() : undefined;
+  const trace = typeof body?.traceId === 'string' ? body.traceId.trim() : undefined;
+  const title = typeof body?.title === 'string' ? body.title.trim() : undefined;
+  const summary = typeof body?.summary === 'string' ? body.summary.trim() : undefined;
+
+  const payload = isPlainRecord(body?.payload) ? body?.payload : undefined;
+  const metadata = isPlainRecord(body?.metadata) ? body?.metadata : undefined;
+
+  const action = isPlainRecord(body?.action) ? body?.action : undefined;
+  const actionLabel = typeof action?.label === 'string' ? action.label : undefined;
+  const actionHref = typeof action?.href === 'string' ? action.href : undefined;
+
+  const occurredAt = typeof body?.occurredAt === 'string' ? new Date(body.occurredAt) : undefined;
+  if (occurredAt && Number.isNaN(occurredAt.getTime())) {
+    return res.status(400).json({
+      error: 'occurredAt 非法',
+      traceId,
+    });
+  }
+
+  try {
+    const event = await appendValueEvent({
+      eventType,
+      status,
+      traceId: trace,
+      title,
+      summary,
+      payload,
+      metadata,
+      actionLabel,
+      actionHref,
+      occurredAt,
+    });
+
+    const auth = getAuthContext(req);
+    if (auth) {
+      console.info('[Events] 新增价值事件', {
+        id: event.id,
+        eventType: event.eventType,
+        actor: auth.subject,
+      });
+    }
+
+    res.status(201).json({ event });
+  } catch (error) {
+    console.error('[Events] 写入失败:', error);
+    res.status(500).json({
+      error: '写入价值事件失败',
+      traceId,
+    });
+  }
+});
+
+router.get('/stream', requireAuth('events.subscribe'), async (req, res) => {
+  const traceId = res.locals.traceId;
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.flushHeaders?.();
+
+  let closed = false;
+  let heartbeat: NodeJS.Timeout | null = null;
+  const pool = getPool();
+  const client = await pool.connect();
+
+  const cleanup = async () => {
+    if (closed) return;
+    closed = true;
+    if (heartbeat) {
+      clearInterval(heartbeat);
+      heartbeat = null;
+    }
+    try {
+      await client.query(`UNLISTEN ${VALUE_EVENT_CHANNEL}`);
+    } catch (error) {
+      console.error('[Events] 取消监听失败', error);
+    }
+    client.release();
+  };
+
+  try {
+    await ensureValueEventInfrastructure();
+    await client.query(`LISTEN ${VALUE_EVENT_CHANNEL}`);
+  } catch (error) {
+    console.error('[Events] 监听价值事件失败:', error);
+    res.write(`event: error\ndata: ${JSON.stringify({ error: '订阅失败', traceId })}\n\n`);
+    await cleanup();
+    res.end();
+    return;
+  }
+
+  const sendEvent = (event: ValueEventRecord) => {
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+  };
+
+  client.on('notification', (msg) => {
+    if (!msg.payload) return;
+    try {
+      const event = mapNotificationPayload(msg.payload);
+      sendEvent(event);
+    } catch (error) {
+      console.error('[Events] 推送解析失败:', error);
+    }
+  });
+
+  client.on('error', async (error) => {
+    console.error('[Events] 通知连接错误:', error);
+    if (!closed) {
+      res.write(`event: error\ndata: ${JSON.stringify({ error: '通知通道异常', traceId })}\n\n`);
+      res.end();
+      await cleanup();
+    }
+  });
+
+  heartbeat = setInterval(() => {
+    if (!closed) {
+      res.write(': heartbeat\n\n');
+    }
+  }, 15000);
+
+  req.on('close', async () => {
+    await cleanup();
+  });
+
+  req.on('end', async () => {
+    await cleanup();
+  });
+
+  res.write(': connected\n\n');
+});
+
+export { router as valueEventRoutes };

--- a/backend/src/routes/projects.ts
+++ b/backend/src/routes/projects.ts
@@ -1,0 +1,92 @@
+import { Router } from 'express';
+import { requireAuth, getAuthContext } from '../auth/middleware';
+import {
+  createProjectRun,
+  getProjectDetail,
+  getRunDetail,
+  listProjectSummaries,
+} from '../services/projects';
+import { appendValueEvent } from '../events/value-events';
+
+const router = Router();
+
+router.get('/', requireAuth('projects.read'), (req, res) => {
+  const projects = listProjectSummaries();
+  res.json({
+    projects,
+    count: projects.length,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+router.get('/:projectId', requireAuth('projects.read'), (req, res) => {
+  const { projectId } = req.params;
+  const detail = getProjectDetail(projectId);
+  if (!detail) {
+    return res.status(404).json({
+      error: '项目不存在',
+      projectId,
+    });
+  }
+  res.json({ project: detail });
+});
+
+router.get('/:projectId/runs/:runId', requireAuth('projects.read'), (req, res) => {
+  const { projectId, runId } = req.params;
+  const run = getRunDetail(projectId, runId);
+  if (!run) {
+    return res.status(404).json({
+      error: '运行记录不存在',
+      projectId,
+      runId,
+    });
+  }
+  res.json({ run });
+});
+
+router.post('/:projectId/runs', requireAuth('projects.execute'), async (req, res) => {
+  const { projectId } = req.params;
+  const { sourceRunId, title, metadata } = (req.body ?? {}) as {
+    sourceRunId?: string;
+    title?: string;
+    metadata?: Record<string, unknown>;
+  };
+
+  const auth = getAuthContext(req);
+  const triggeredBy = auth?.subject ?? 'system';
+
+  try {
+    const run = createProjectRun(projectId, {
+      title,
+      sourceRunId,
+      metadata,
+      triggeredBy,
+    });
+
+    await appendValueEvent({
+      eventType: sourceRunId ? 'task.replay.requested' : 'task.submitted',
+      status: 'pending',
+      title: `${run.title} - ${sourceRunId ? '重新执行' : '新任务'}`,
+      summary: sourceRunId
+        ? `触发对运行 ${sourceRunId} 的重新执行，已排队等待资源`
+        : '任务已提交调度，等待执行',
+      traceId: run.traceId,
+      metadata: {
+        projectId,
+        runId: run.id,
+        sourceRunId,
+      },
+      actionLabel: '打开回放',
+      actionHref: `/projects/${projectId}?run=${run.id}`,
+    });
+
+    res.status(201).json({ run });
+  } catch (error) {
+    console.error('[Projects] 创建运行失败:', error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : '创建运行失败',
+    });
+  }
+});
+
+export default router;

--- a/backend/src/services/projects.ts
+++ b/backend/src/services/projects.ts
@@ -1,0 +1,422 @@
+import { randomUUID } from 'crypto';
+
+export type ProjectRunStatus = 'queued' | 'running' | 'success' | 'failed' | 'cancelled';
+
+export interface RunArtifact {
+  id: string;
+  name: string;
+  type: 'log' | 'file' | 'dataset' | 'report';
+  size: number;
+  downloadUrl?: string;
+}
+
+export interface RunTimelineEntry {
+  id: string;
+  label: string;
+  status: 'pending' | 'completed' | 'error' | 'running';
+  description?: string;
+  occurredAt?: string;
+}
+
+export interface ProjectRunRecord {
+  id: string;
+  projectId: string;
+  title: string;
+  status: ProjectRunStatus;
+  owner: string;
+  triggeredBy: string;
+  startedAt: string;
+  finishedAt?: string;
+  traceId: string;
+  summary: string;
+  approvalRequired: boolean;
+  timeline: RunTimelineEntry[];
+  artifacts: RunArtifact[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface SopBlueprintVersion {
+  id: string;
+  name: string;
+  version: string;
+  status: 'active' | 'draft' | 'archived';
+  updatedAt: string;
+  description?: string;
+  editor?: string;
+}
+
+export interface ProjectRecord {
+  id: string;
+  name: string;
+  description?: string;
+  owner: string;
+  tags: string[];
+  runs: ProjectRunRecord[];
+  sopVersions: SopBlueprintVersion[];
+}
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string;
+  owner: string;
+  tags: string[];
+  latestRun?: ProjectRunRecord;
+  activeRuns: ProjectRunRecord[];
+  queuedRuns: ProjectRunRecord[];
+  completedRuns: ProjectRunRecord[];
+  sopVersions: SopBlueprintVersion[];
+}
+
+export type ProjectRunDetail = ProjectRunRecord;
+
+const inMemoryProjects: ProjectRecord[] = [
+  {
+    id: 'proj-content-review',
+    name: '视频审核 SOP',
+    description: '内容安全团队的视频审核流程，涵盖采样、检测与人工复核',
+    owner: 'ops-team',
+    tags: ['safety', 'media'],
+    sopVersions: [
+      {
+        id: 'sop-014',
+        name: '视频审核 SOP',
+        version: 'v3.2',
+        status: 'active',
+        updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 10).toISOString(),
+        description: '接入最新的异常检测模型，新增多模态审计步骤',
+        editor: 'zhangsan',
+      },
+      {
+        id: 'sop-013',
+        name: '视频审核 SOP',
+        version: 'v3.1',
+        status: 'archived',
+        updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 3).toISOString(),
+        editor: 'zhangsan',
+      },
+    ],
+    runs: [],
+  },
+  {
+    id: 'proj-dataset-clean',
+    name: '数据集清洗',
+    description: '针对训练数据集的周期性清洗与质检',
+    owner: 'ml-platform',
+    tags: ['ml', 'ops'],
+    sopVersions: [
+      {
+        id: 'sop-020',
+        name: '训练数据质检 SOP',
+        version: 'v1.8',
+        status: 'active',
+        updatedAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+        editor: 'lisi',
+      },
+    ],
+    runs: [],
+  },
+];
+
+const seedRuns = () => {
+  if (inMemoryProjects[0].runs.length) {
+    return;
+  }
+
+  const now = Date.now();
+
+  const makeTimeline = (offsets: number[]): RunTimelineEntry[] => {
+    return offsets.map((offset, index) => ({
+      id: `step-${index + 1}`,
+      label: ['排队等待', 'MCP 工具执行', '人工复核', '归档出品'][index] ?? `阶段 ${index + 1}`,
+      status: 'completed',
+      occurredAt: new Date(now - offset).toISOString(),
+      description: ['排队进入执行队列', '调用多模态检测 MCP 服务', '质检员复核 20% 样本', '归档并产出审核报告'][index],
+    }));
+  };
+
+  const completedRun: ProjectRunRecord = {
+    id: 'run-20240928-001',
+    projectId: 'proj-content-review',
+    title: '短视频批次审核',
+    status: 'success',
+    owner: 'ops-team',
+    triggeredBy: 'system@ops',
+    startedAt: new Date(now - 1000 * 60 * 90).toISOString(),
+    finishedAt: new Date(now - 1000 * 60 * 5).toISOString(),
+    traceId: 'trace-content-001',
+    summary: '批次共 320 条视频，发现 5 条需人工复核，最终出具审核报告',
+    approvalRequired: true,
+    timeline: makeTimeline([1000 * 60 * 90, 1000 * 60 * 70, 1000 * 60 * 30, 1000 * 60 * 5]),
+    artifacts: [
+      {
+        id: 'artifact-report-001',
+        name: '审核报告.pdf',
+        type: 'report',
+        size: 2.4 * 1024 * 1024,
+        downloadUrl: '/artifacts/report-001.pdf',
+      },
+      {
+        id: 'artifact-log-001',
+        name: '执行日志.log',
+        type: 'log',
+        size: 1.2 * 1024 * 1024,
+        downloadUrl: '/artifacts/log-001.log',
+      },
+    ],
+    metadata: {
+      approval: {
+        approver: 'auditor.liu',
+        status: 'approved',
+        occurredAt: new Date(now - 1000 * 60 * 6).toISOString(),
+      },
+    },
+  };
+
+  const runningRun: ProjectRunRecord = {
+    id: 'run-20240928-002',
+    projectId: 'proj-content-review',
+    title: '直播内容抽检',
+    status: 'running',
+    owner: 'ops-team',
+    triggeredBy: 'ops.li',
+    startedAt: new Date(now - 1000 * 60 * 15).toISOString(),
+    traceId: 'trace-content-002',
+    summary: '抽检直播流 50 条，等待多模态检测结果',
+    approvalRequired: false,
+    timeline: [
+      {
+        id: 'step-1',
+        label: '排队等待',
+        status: 'completed',
+        occurredAt: new Date(now - 1000 * 60 * 15).toISOString(),
+        description: '作业开始排队等待资源',
+      },
+      {
+        id: 'step-2',
+        label: 'MCP 工具执行',
+        status: 'running',
+        occurredAt: new Date(now - 1000 * 60 * 10).toISOString(),
+        description: '调用内容检测工具',
+      },
+      {
+        id: 'step-3',
+        label: '人工复核',
+        status: 'pending',
+        description: '等待检测结果后触发人工抽检',
+      },
+    ],
+    artifacts: [],
+  };
+
+  const queuedRun: ProjectRunRecord = {
+    id: 'run-20240928-003',
+    projectId: 'proj-content-review',
+    title: '跨境内容抽查',
+    status: 'queued',
+    owner: 'ops-team',
+    triggeredBy: 'system@ops',
+    startedAt: new Date(now - 1000 * 60 * 2).toISOString(),
+    traceId: 'trace-content-003',
+    summary: '等待调度窗口释放 GPU 资源',
+    approvalRequired: false,
+    timeline: [
+      {
+        id: 'step-1',
+        label: '排队等待',
+        status: 'running',
+        occurredAt: new Date(now - 1000 * 60 * 2).toISOString(),
+        description: '排队中，未开始执行',
+      },
+    ],
+    artifacts: [],
+  };
+
+  inMemoryProjects[0].runs = [runningRun, queuedRun, completedRun];
+  inMemoryProjects[1].runs = [
+    {
+      id: 'run-20240927-101',
+      projectId: 'proj-dataset-clean',
+      title: '英文语料清洗',
+      status: 'success',
+      owner: 'ml-platform',
+      triggeredBy: 'scheduler',
+      startedAt: new Date(now - 1000 * 60 * 300).toISOString(),
+      finishedAt: new Date(now - 1000 * 60 * 150).toISOString(),
+      traceId: 'trace-dataset-001',
+      summary: '完成英文语料清洗并更新差分报告',
+      approvalRequired: false,
+      timeline: makeTimeline([1000 * 60 * 300, 1000 * 60 * 240, 1000 * 60 * 210, 1000 * 60 * 150]),
+      artifacts: [
+        {
+          id: 'artifact-report-201',
+          name: '质检报告.json',
+          type: 'report',
+          size: 860 * 1024,
+          downloadUrl: '/artifacts/diff-report.json',
+        },
+      ],
+    },
+  ];
+};
+
+seedRuns();
+
+const cloneRun = (run: ProjectRunRecord): ProjectRunRecord => ({
+  ...run,
+  timeline: run.timeline.map((entry) => ({ ...entry })),
+  artifacts: run.artifacts.map((artifact) => ({ ...artifact })),
+  metadata: run.metadata ? { ...run.metadata } : undefined,
+});
+
+const sortRuns = (runs: ProjectRunRecord[]) => {
+  return [...runs].sort((a, b) => {
+    const aTime = new Date(a.startedAt).getTime();
+    const bTime = new Date(b.startedAt).getTime();
+    return bTime - aTime;
+  });
+};
+
+export const listProjectSummaries = (): ProjectSummary[] => {
+  return inMemoryProjects.map((project) => {
+    const sorted = sortRuns(project.runs);
+    const activeRuns = sorted.filter((run) => run.status === 'running').map((run) => cloneRun(run));
+    const queuedRuns = sorted.filter((run) => run.status === 'queued').map((run) => cloneRun(run));
+    const completedRuns = sorted
+      .filter((run) => run.status === 'success' || run.status === 'failed' || run.status === 'cancelled')
+      .map((run) => cloneRun(run));
+    return {
+      id: project.id,
+      name: project.name,
+      description: project.description,
+      owner: project.owner,
+      tags: project.tags,
+      latestRun: sorted[0] ? cloneRun(sorted[0]) : undefined,
+      activeRuns,
+      queuedRuns,
+      completedRuns: completedRuns.slice(0, 5),
+      sopVersions: project.sopVersions.map((version) => ({ ...version })),
+    };
+  });
+};
+
+export const getProjectDetail = (projectId: string): ProjectRecord | null => {
+  const record = inMemoryProjects.find((project) => project.id === projectId);
+  if (!record) {
+    return null;
+  }
+  return {
+    ...record,
+    runs: sortRuns(record.runs).map((run) => cloneRun(run)),
+    sopVersions: record.sopVersions.map((version) => ({ ...version })),
+  };
+};
+
+export const getRunDetail = (
+  projectId: string,
+  runId: string,
+): ProjectRunDetail | null => {
+  const project = inMemoryProjects.find((item) => item.id === projectId);
+  if (!project) return null;
+  const run = project.runs.find((item) => item.id === runId);
+  if (!run) return null;
+  return cloneRun(run);
+};
+
+export interface CreateRunOptions {
+  title?: string;
+  triggeredBy: string;
+  sourceRunId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export const createProjectRun = (
+  projectId: string,
+  options: CreateRunOptions,
+): ProjectRunRecord => {
+  const project = inMemoryProjects.find((item) => item.id === projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  const sourceRun = options.sourceRunId
+    ? project.runs.find((run) => run.id === options.sourceRunId)
+    : undefined;
+
+  const baseTitle = options.title?.trim() || sourceRun?.title || '新建任务';
+
+  const now = Date.now();
+  const newRun: ProjectRunRecord = {
+    id: `run-${new Date().toISOString().replace(/[-:T.Z]/g, '').slice(0, 12)}-${Math.floor(
+      Math.random() * 1000,
+    )}`,
+    projectId: project.id,
+    title: baseTitle,
+    status: 'queued',
+    owner: project.owner,
+    triggeredBy: options.triggeredBy,
+    startedAt: new Date(now).toISOString(),
+    traceId: `trace-${randomUUID()}`,
+    summary:
+      sourceRun?.summary ||
+      '任务已提交至调度队列，等待资源分配。',
+    approvalRequired: sourceRun?.approvalRequired ?? false,
+    timeline: [
+      {
+        id: 'step-queue',
+        label: '排队等待',
+        status: 'running',
+        occurredAt: new Date(now).toISOString(),
+        description: '任务排队中，等待调度器分配运行环境',
+      },
+      ...(sourceRun
+        ? sourceRun.timeline
+            .filter((entry) => entry.id !== 'step-queue')
+            .map((entry) => ({
+              ...entry,
+              status: 'pending',
+              occurredAt: undefined,
+            }))
+        : []),
+    ],
+    artifacts: [],
+    metadata: options.metadata,
+  };
+
+  project.runs.unshift(newRun);
+  return cloneRun(newRun);
+};
+
+export const updateRunStatus = (
+  projectId: string,
+  runId: string,
+  status: ProjectRunStatus,
+  fields: Partial<Pick<ProjectRunRecord, 'finishedAt' | 'summary' | 'timeline' | 'artifacts'>> = {},
+) => {
+  const project = inMemoryProjects.find((item) => item.id === projectId);
+  if (!project) {
+    throw new Error(`Project not found: ${projectId}`);
+  }
+
+  const run = project.runs.find((item) => item.id === runId);
+  if (!run) {
+    throw new Error(`Run not found: ${runId}`);
+  }
+
+  run.status = status;
+  if (fields.finishedAt !== undefined) {
+    run.finishedAt = fields.finishedAt;
+  }
+  if (fields.summary !== undefined) {
+    run.summary = fields.summary;
+  }
+  if (fields.timeline !== undefined) {
+    run.timeline = fields.timeline;
+  }
+  if (fields.artifacts !== undefined) {
+    run.artifacts = fields.artifacts;
+  }
+
+  return cloneRun(run);
+};
+

--- a/docs/feature-gap-analysis.md
+++ b/docs/feature-gap-analysis.md
@@ -4,46 +4,57 @@
 
 ## 1. Chat Hub（`/`）
 - **现状**：
-  - 支持与后端聊天流式接口交互，并将响应写入本地存储，保留会话多标签。`app/page.tsx` 第 320-438 行。 
-  - 接入 `/api/logs` + SSE 流，读取遥测日志并转换为价值事件卡片占位。`app/page.tsx` 第 332-394 行。 
+  - 支持与后端聊天流式接口交互，并将响应写入本地存储，保留会话多标签。`app/page.tsx` 第 320-438 行。
+  - 接入 `/api/logs` + SSE 流，读取遥测日志并转换为价值事件卡片占位。`app/page.tsx` 第 332-394 行。
+  - 价值事件卡片挂载跳转入口，可打开 Projects 回放页查看运行详情。`app/page.tsx` 第 260-340 行。
 - **待落地**：
-  - 打通价值事件总线，按蓝图引入 `task.acceptance/task.receipt/anomaly.*` 等 Outbox 事件并去抖显示。`docs/aos-v0.1-blueprint.md` 第 64-82 行。 
-  - 事件卡片需要挂载审批/回放入口，跳转项目回放与审批流程。`docs/aos-v0.1-blueprint.md` 第 69-82 行。 
-  - 会话上下文需要绑定 Trace/Agent 运行，联动 Projects/Telemetry 页面。`docs/aos-v0.1-blueprint.md` 第 173-202 行。 
+  - 打通价值事件总线，按蓝图引入 `task.acceptance/task.receipt/anomaly.*` 等 Outbox 事件并去抖显示。`docs/aos-v0.1-blueprint.md` 第 64-82 行。
+  - 会话上下文需要绑定 Trace/Agent 运行，联动 Projects/Telemetry 页面。`docs/aos-v0.1-blueprint.md` 第 173-202 行。
 
 ## 2. Telemetry（`/telemetry`）
 - **现状**：
-  - 页面已提供追踪、日志、指标的拉取与可视化骨架，依赖后端 `/api/telemetry/*`。`app/telemetry/page.tsx` 第 312-470 行。 
-  - 后端 Telemetry 路由打通 NATS JetStream 读取。`backend/src/routes/telemetry.ts` 第 15-198 行。 
+  - 页面已提供追踪、日志、指标的拉取与可视化骨架，依赖后端 `/api/telemetry/*`。`app/telemetry/page.tsx` 第 312-470 行。
+  - 后端 Telemetry 路由打通 NATS JetStream 读取。`backend/src/routes/telemetry.ts` 第 15-198 行。
+  - Trace 瀑布视图落地，展示 Span 层级、时间轴与属性摘要，并允许通过查询参数定位指定 Trace。`app/telemetry/page.tsx` 第 150-260 行，第 500-560 行。
+  - Chat Hub 价值事件自动补充 Trace 快捷入口，可一键跳转遥测页查看详情。`app/page.tsx` 第 260-360 行。
 - **待落地**：
-  - 引入 Trace 瀑布图/拓扑视图与多维筛选。`docs/aos-v0.1-blueprint.md` 第 33-55 行。 
-  - 支持与 Chat Hub 价值事件关联跳转，定位指定 trace。`docs/aos-v0.1-blueprint.md` 第 69-82 行。 
+  - 拓扑视角、服务依赖图与多维筛选（按 Agent/环境/状态）。`docs/aos-v0.1-blueprint.md` 第 33-55 行。
 
 ## 3. Integrations（`/integrations`）
 - **现状**：
-  - 已可 CRUD MCP 服务注册、配置角色白名单与限流参数。`app/integrations/page.tsx` 第 1-200 行。 
-  - 后端 MCP registry API/网关基本可用，含 RBAC 与审计打点。`backend/src/routes/mcp.ts` 第 1-260 行。 
+  - 已可 CRUD MCP 服务注册、配置角色白名单与限流参数。`app/integrations/page.tsx` 第 1-200 行。
+  - 后端 MCP registry API/网关基本可用，含 RBAC 与审计打点。`backend/src/routes/mcp.ts` 第 1-260 行。
+  - 集成健康检查、熔断与配额监控，页面展示调用成功率/延迟并可一键巡检、在线调整策略。`backend/src/mcp/monitor.ts`、`app/integrations/page.tsx`。
 - **待落地**：
-  - 接入服务健康检查、配额统计、熔断策略管理。`docs/aos-v0.1-blueprint.md` 第 117-145 行。 
-  - 需要 UI 告警提示失败状态，并与 Telemetry 事件联动。`docs/aos-v0.1-blueprint.md` 第 117-145 行。 
+  - 需要 UI 告警提示失败状态，并与 Telemetry 事件联动。`docs/aos-v0.1-blueprint.md` 第 117-145 行。
 
 ## 4. Sandbox & Agents（`/sandbox`, `/agents`）
 - **现状**：
-  - Sandbox 页面支持虚拟环境的增删改查、变量管理并与 Token 存储打通。`app/sandbox/page.tsx` 第 1-200 行。 
-  - Agents 页面能管理脚本、绑定环境、查看运行记录并手动触发执行。`app/agents/page.tsx` 第 1-200 行。 
-  - 后端 Sandbox/MCP API 支持环境注册、脚本写入、运行日志查询。`backend/src/routes/mcp.ts` 第 82-420 行。 
+  - Sandbox 页面支持虚拟环境的增删改查、变量管理并与 Token 存储打通。`app/sandbox/page.tsx` 第 1-200 行。
+  - Agents 页面能管理脚本、绑定环境、查看运行记录并手动触发执行。`app/agents/page.tsx` 第 1-200 行。
+  - 后端 Sandbox/MCP API 支持环境注册、脚本写入、运行日志查询。`backend/src/routes/mcp.ts` 第 82-420 行。
+- **定位与职责对齐**：
+  - 沙箱仍是 Agent 的运行环境，支持在界面内创建、编辑、删除不同的隔离运行态，并提供默认空白环境便于试验。
+  - 沙箱封装的 MCP Server 对外暴露工具能力，供企业内外部系统调用；AOS 内的 Agent 可在自身配置页动态绑定/解绑 MCP 端点与沙箱环境，并回写运行事件。
+  - Integrations 入口下新增“沙箱管理”二级页面，负责沙箱的 CRUD、变量引用、默认模板等配置；同处一级的 MCP 管理页负责注册/授权 MCP 服务，并可为沙箱绑定的 Agent 调整权限范围。
+  - Agent 与沙箱的绑定关系决定了其可访问的 MCP 端点与变量范围，运行结果写入 `events/agent_runs` 并同步至 Telemetry/审计。
+- **公共变量注入方案（建议）**：
+  - 由 AOS 统一提供 "Runtime Env Directory" MCP 服务，用于查询平台登记的 Secrets、连接信息、调度参数的环境变量名称与作用域描述；Integrations/Settings 侧负责录入与审批。
+  - 创建沙箱或运行任务时，仅写入变量引用（`ref://env/<namespace>/<key>`），执行容器在启动阶段通过 MCP 拉取具体值并注入进程环境，未显式引用的变量不会下发，支持按需注入。
+  - 权限控制采用三段式策略：① 变量以命名空间划分租户/项目；② Agent 绑定沙箱时声明所需引用，由管理员审批；③ MCP 层校验调用者 Token 与租户、角色，审计所有读取行为，支持后续细粒度撤权。
 - **待落地**：
-  - 新增 Agent 模板与版本管理、伸缩/调度策略。`docs/aos-v0.1-blueprint.md` 第 146-171 行。 
-  - 打通脚本执行产物上传、运行态日志回放与 MCP 网关自动注册。`docs/aos-v0.1-blueprint.md` 第 146-171 行。 
-  - 引入运行健康度与告警（结合 Telemetry + 审计）。`docs/aos-v0.1-blueprint.md` 第 146-171 行。 
+  - 新增 Agent 模板与版本管理、伸缩/调度策略。`docs/aos-v0.1-blueprint.md` 第 146-171 行。
+  - 打通脚本执行产物上传、运行态日志回放与 MCP 网关自动注册。`docs/aos-v0.1-blueprint.md` 第 146-171 行。
+  - 引入运行健康度与告警（结合 Telemetry + 审计）。`docs/aos-v0.1-blueprint.md` 第 146-171 行。
 
 ## 5. Projects（`/projects`）
 - **现状**：
-  - 页面为静态占位，展示 mock 任务与 SOP 列表，回放功能未实现。`app/projects/page.tsx` 第 1-160 行。 
+  - 接入 `/api/projects` 后端，支持项目列表、运行中/排队任务、近期完成记录及 SOP 版本展示。`app/projects/page.tsx` 第 1-420 行。
+  - 提供运行详情抽屉（时间线、产物、Trace ID）、重跑按钮，并写入价值事件 Outbox。`app/projects/page.tsx` 第 180-420 行，`backend/src/routes/projects.ts`。
+  - 后端新增 Projects 服务层与路由，模拟任务回放数据并与 Outbox 对接。`backend/src/services/projects.ts`、`backend/src/routes/projects.ts`。
 - **待落地**：
-  - 接入任务队列/回放 API，支撑任务列表、重跑、工件查看。`docs/aos-v0.1-blueprint.md` 第 83-116 行。 
-  - 按蓝图实现 SOP 蓝图版本化、可视编辑与审批链路。`docs/aos-v0.1-blueprint.md` 第 83-116 行。 
-  - 与 Chat Hub 的价值事件卡片打通，支持 trace → 回放跳转。`docs/aos-v0.1-blueprint.md` 第 69-82 行。 
+  - 接入真实任务队列/回放 API，替换内存模拟数据并串联实际工件存储。`docs/aos-v0.1-blueprint.md` 第 83-116 行。
+  - 按蓝图实现 SOP 蓝图版本化、可视编辑与审批链路。`docs/aos-v0.1-blueprint.md` 第 83-116 行。
 
 ## 6. Memory（`/memory`）
 - **现状**：
@@ -61,10 +72,12 @@
 
 ## 8. 事件总线与持久化
 - **现状**：
-  - Telemetry 通过 NATS JetStream 存储并可拉取。`backend/src/telemetry/nats-exporter.ts` 第 1-220 行。 
-  - LangGraph 检查点落地 PostgreSQL，但 Outbox 价值事件尚未实现。`docs/aos-v0.1-blueprint.md` 第 64-82 行、`backend/src/db/index.ts` 第 1-160 行。 
+  - Telemetry 通过 NATS JetStream 存储并可拉取。`backend/src/telemetry/nats-exporter.ts` 第 1-220 行。
+  - LangGraph 检查点落地 PostgreSQL，新增 `value_events` Outbox 表与触发器，支撑价值事件持久化。`backend/src/events/value-events.ts`。
+  - Projects 重跑操作写入 `task.submitted/task.replay.requested` 价值事件并附带回放链接。`backend/src/routes/projects.ts`。
 - **待落地**：
-  - 完成 Postgres Outbox + `LISTEN/NOTIFY` 推送价值事件，并提供回放索引。`docs/aos-v0.1-blueprint.md` 第 64-116 行。 
+  - 将 Chat Hub 价值事件卡片与 Projects/Telemetry 的审批、回放入口串联，支撑端到端验收。`docs/aos-v0.1-blueprint.md` 第 69-116 行。
+  - 将 Orchestrator/任务流水接入价值事件 Outbox，补齐 `task.*`、`anomaly.*` 的生成与索引回放能力。`docs/aos-v0.1-blueprint.md` 第 64-116 行。
   - 引入 `jobs`、`agent_runs`、`audit_logs` 等表结构与 API。`docs/aos-v0.1-blueprint.md` 第 173-246 行。 
   - 规划向 NATS/Redis Streams 的升级路径与 ClickHouse OLAP。`docs/aos-v0.1-blueprint.md` 第 289-320 行。 
 

--- a/lib/apiConfig.ts
+++ b/lib/apiConfig.ts
@@ -26,3 +26,7 @@ export const getChatStreamEndpoint = () => `${getApiBaseUrl()}/api/chat/stream`;
 export const telemetryEndpoint = (path: string) => `${getApiBaseUrl()}/api/telemetry/${path}`;
 
 export const getMcpEndpoint = (path: string) => `${getApiBaseUrl()}/mcp${path}`;
+export const getProjectsEndpoint = (path = '') => {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${getApiBaseUrl()}/api/projects${normalized === '/' ? '' : normalized}`;
+};


### PR DESCRIPTION
## Summary
- add MCP service monitor to persist quota and circuit-breaker policies and expose health status APIs
- extend gateway and routes to enforce quotas, surface circuit errors, and trigger manual health checks with audit logs
- update integrations UI with health panels, policy editor, and documentation of the new monitoring capability

## Testing
- npm run lint *(fails: repository still contains existing @typescript-eslint/no-explicit-any violations)*

------
https://chatgpt.com/codex/tasks/task_e_68e7751534a4832badcd057d98eaa7d4