### PR TITLE
修复 cn 工具函数并增强价值事件解析测试

### DIFF
--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -78,7 +78,7 @@ const roleOptions = [
 const capabilityOptions = [
   { value: "tools", label: "工具" },
   { value: "files", label: "文件" },
-  { value: "secrets", label: "秘钥" },
+  { value: "secrets", label: "密钥" },
   { value: "events", label: "事件" },
 ];
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
-    "test": "jest"
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@langchain/community": "^0.3.17",

--- a/backend/src/events/value-events.test.ts
+++ b/backend/src/events/value-events.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mapNotificationPayload } from './value-events';
+
+describe('mapNotificationPayload', () => {
+  it('能解析 JSON 字符串并填充默认字段', () => {
+    const payload = JSON.stringify({
+      id: 123,
+      eventType: 'task.progress',
+      status: '  ',
+      title: '处理进度更新',
+      summary: '任务已完成 50%',
+      traceId: 'trace-001',
+      occurredAt: '2024-10-01T00:00:00.000Z',
+      action: {
+        label: '查看详情',
+        href: '/projects/foo?run=bar',
+      },
+      metadata: { foo: 'bar' },
+    });
+
+    const result = mapNotificationPayload(payload);
+
+    assert.equal(result.id, '123');
+    assert.equal(result.eventType, 'task.progress');
+    assert.equal(result.status, 'active');
+    assert.equal(result.title, '处理进度更新');
+    assert.equal(result.summary, '任务已完成 50%');
+    assert.equal(result.traceId, 'trace-001');
+    assert.equal(result.occurredAt, '2024-10-01T00:00:00.000Z');
+    assert.deepEqual(result.metadata, { foo: 'bar' });
+    assert.deepEqual(result.action, { label: '查看详情', href: '/projects/foo?run=bar' });
+  });
+
+  it('在收到无法解析的内容时返回安全默认值', () => {
+    const resultFromText = mapNotificationPayload('not-json');
+    assert.equal(resultFromText.title, '解析通知失败');
+    assert.equal(resultFromText.status, 'active');
+
+    const resultFromUnknown = mapNotificationPayload(42 as unknown);
+    assert.equal(resultFromUnknown.title, '未知事件');
+    assert.equal(resultFromUnknown.summary, '无法解析价值事件通知。');
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,7 +28,7 @@ app.use(cors({
     process.env.FRONTEND_URL || 'http://localhost:3001',
     'http://localhost:3000',
     'http://localhost:3001',
-    /^http:\/\/.*\..*$/  // Allow any localhost variations
+    /^http:\/\/.*\..*$/  // 允许任意带点的 http:// 来源，例如内网调试域名
   ],
   credentials: true,
 }));

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,5 +2,5 @@ import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(...inputs))
 }


### PR DESCRIPTION
## 摘要
- 修复 `cn` 工具函数未展开参数导致 tailwind 类名无法正确合并的问题
- 调整 Integrations 页面“秘钥”文案并同步后端 CORS 注释描述
- 为价值事件通知解析补充 node:test 用例并将 test 脚本改为 `tsx --test`

## 测试
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e85b2ab51c832bb8a499e04f498d3f